### PR TITLE
Update aws-cli to most recent version

### DIFF
--- a/ubuntu/android-java-6/24.4.1/Dockerfile
+++ b/ubuntu/android-java-6/24.4.1/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update \
 
 RUN wget "https://bootstrap.pypa.io/get-pip.py" -O /tmp/get-pip.py \
     && python /tmp/get-pip.py \
-    && pip install awscli==1.11.108 \
+    && pip install awscli==1.11.112 \
     && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/* 
  
 

--- a/ubuntu/android-java-6/24.4.1/Dockerfile
+++ b/ubuntu/android-java-6/24.4.1/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update \
 
 RUN wget "https://bootstrap.pypa.io/get-pip.py" -O /tmp/get-pip.py \
     && python /tmp/get-pip.py \
-    && pip install awscli==1.11.25 \
+    && pip install awscli==1.11.108 \
     && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/* 
  
 

--- a/ubuntu/android-java-7/24.4.1/Dockerfile
+++ b/ubuntu/android-java-7/24.4.1/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update \
 
 RUN wget "https://bootstrap.pypa.io/get-pip.py" -O /tmp/get-pip.py \
     && python /tmp/get-pip.py \
-    && pip install awscli==1.11.108 \
+    && pip install awscli==1.11.112 \
     && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/* 
  
 

--- a/ubuntu/android-java-7/24.4.1/Dockerfile
+++ b/ubuntu/android-java-7/24.4.1/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update \
 
 RUN wget "https://bootstrap.pypa.io/get-pip.py" -O /tmp/get-pip.py \
     && python /tmp/get-pip.py \
-    && pip install awscli==1.11.25 \
+    && pip install awscli==1.11.108 \
     && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/* 
  
 

--- a/ubuntu/android-java-8/24.4.1/Dockerfile
+++ b/ubuntu/android-java-8/24.4.1/Dockerfile
@@ -41,9 +41,9 @@ RUN apt-get update \
 
 RUN wget "https://bootstrap.pypa.io/get-pip.py" -O /tmp/get-pip.py \
     && python /tmp/get-pip.py \
-    && pip install awscli==1.11.25 \
-    && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/* 
- 
+    && pip install awscli==1.11.108 \
+    && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
 
 # Copy install tools
 COPY tools /opt/tools

--- a/ubuntu/android-java-8/24.4.1/Dockerfile
+++ b/ubuntu/android-java-8/24.4.1/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update \
 
 RUN wget "https://bootstrap.pypa.io/get-pip.py" -O /tmp/get-pip.py \
     && python /tmp/get-pip.py \
-    && pip install awscli==1.11.108 \
+    && pip install awscli==1.11.112 \
     && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 

--- a/ubuntu/docker/1.12.1/Dockerfile
+++ b/ubuntu/docker/1.12.1/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update \
 
 RUN wget "https://bootstrap.pypa.io/get-pip.py" -O /tmp/get-pip.py \
     && python /tmp/get-pip.py \
-    && pip install awscli==1.11.108 \
+    && pip install awscli==1.11.112 \
     && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 

--- a/ubuntu/docker/1.12.1/Dockerfile
+++ b/ubuntu/docker/1.12.1/Dockerfile
@@ -41,9 +41,9 @@ RUN apt-get update \
 
 RUN wget "https://bootstrap.pypa.io/get-pip.py" -O /tmp/get-pip.py \
     && python /tmp/get-pip.py \
-    && pip install awscli==1.11.25 \
-    && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/* 
- 
+    && pip install awscli==1.11.108 \
+    && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
 
 ENV DOCKER_BUCKET="get.docker.com" \
     DOCKER_VERSION="1.12.1" \

--- a/ubuntu/golang/1.5.4/Dockerfile
+++ b/ubuntu/golang/1.5.4/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update \
 
 RUN wget "https://bootstrap.pypa.io/get-pip.py" -O /tmp/get-pip.py \
     && python /tmp/get-pip.py \
-    && pip install awscli==1.11.108 \
+    && pip install awscli==1.11.112 \
     && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/* 
  
 

--- a/ubuntu/golang/1.5.4/Dockerfile
+++ b/ubuntu/golang/1.5.4/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update \
 
 RUN wget "https://bootstrap.pypa.io/get-pip.py" -O /tmp/get-pip.py \
     && python /tmp/get-pip.py \
-    && pip install awscli==1.11.25 \
+    && pip install awscli==1.11.108 \
     && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/* 
  
 

--- a/ubuntu/golang/1.6.3/Dockerfile
+++ b/ubuntu/golang/1.6.3/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update \
 
 RUN wget "https://bootstrap.pypa.io/get-pip.py" -O /tmp/get-pip.py \
     && python /tmp/get-pip.py \
-    && pip install awscli==1.11.108 \
+    && pip install awscli==1.11.112 \
     && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/* 
  
 

--- a/ubuntu/golang/1.6.3/Dockerfile
+++ b/ubuntu/golang/1.6.3/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update \
 
 RUN wget "https://bootstrap.pypa.io/get-pip.py" -O /tmp/get-pip.py \
     && python /tmp/get-pip.py \
-    && pip install awscli==1.11.25 \
+    && pip install awscli==1.11.108 \
     && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/* 
  
 

--- a/ubuntu/golang/1.7.3/Dockerfile
+++ b/ubuntu/golang/1.7.3/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update \
 
 RUN wget "https://bootstrap.pypa.io/get-pip.py" -O /tmp/get-pip.py \
     && python /tmp/get-pip.py \
-    && pip install awscli==1.11.108 \
+    && pip install awscli==1.11.112 \
     && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/* 
  
 

--- a/ubuntu/golang/1.7.3/Dockerfile
+++ b/ubuntu/golang/1.7.3/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update \
 
 RUN wget "https://bootstrap.pypa.io/get-pip.py" -O /tmp/get-pip.py \
     && python /tmp/get-pip.py \
-    && pip install awscli==1.11.25 \
+    && pip install awscli==1.11.108 \
     && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/* 
  
 

--- a/ubuntu/java/openjdk-6/Dockerfile
+++ b/ubuntu/java/openjdk-6/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update \
 
 RUN wget "https://bootstrap.pypa.io/get-pip.py" -O /tmp/get-pip.py \
     && python /tmp/get-pip.py \
-    && pip install awscli==1.11.108 \
+    && pip install awscli==1.11.112 \
     && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/* 
  
 

--- a/ubuntu/java/openjdk-6/Dockerfile
+++ b/ubuntu/java/openjdk-6/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update \
 
 RUN wget "https://bootstrap.pypa.io/get-pip.py" -O /tmp/get-pip.py \
     && python /tmp/get-pip.py \
-    && pip install awscli==1.11.25 \
+    && pip install awscli==1.11.108 \
     && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/* 
  
 

--- a/ubuntu/java/openjdk-7/Dockerfile
+++ b/ubuntu/java/openjdk-7/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update \
 
 RUN wget "https://bootstrap.pypa.io/get-pip.py" -O /tmp/get-pip.py \
     && python /tmp/get-pip.py \
-    && pip install awscli==1.11.108 \
+    && pip install awscli==1.11.112 \
     && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/* 
  
 

--- a/ubuntu/java/openjdk-7/Dockerfile
+++ b/ubuntu/java/openjdk-7/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update \
 
 RUN wget "https://bootstrap.pypa.io/get-pip.py" -O /tmp/get-pip.py \
     && python /tmp/get-pip.py \
-    && pip install awscli==1.11.25 \
+    && pip install awscli==1.11.108 \
     && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/* 
  
 

--- a/ubuntu/java/openjdk-8/Dockerfile
+++ b/ubuntu/java/openjdk-8/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update \
 
 RUN wget "https://bootstrap.pypa.io/get-pip.py" -O /tmp/get-pip.py \
     && python /tmp/get-pip.py \
-    && pip install awscli==1.11.108 \
+    && pip install awscli==1.11.112 \
     && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/* 
  
 

--- a/ubuntu/java/openjdk-8/Dockerfile
+++ b/ubuntu/java/openjdk-8/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update \
 
 RUN wget "https://bootstrap.pypa.io/get-pip.py" -O /tmp/get-pip.py \
     && python /tmp/get-pip.py \
-    && pip install awscli==1.11.25 \
+    && pip install awscli==1.11.108 \
     && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/* 
  
 

--- a/ubuntu/nodejs/4.3.2/Dockerfile
+++ b/ubuntu/nodejs/4.3.2/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update \
 
 RUN wget "https://bootstrap.pypa.io/get-pip.py" -O /tmp/get-pip.py \
     && python /tmp/get-pip.py \
-    && pip install awscli==1.11.108 \
+    && pip install awscli==1.11.112 \
     && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/* 
  
 

--- a/ubuntu/nodejs/4.3.2/Dockerfile
+++ b/ubuntu/nodejs/4.3.2/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update \
 
 RUN wget "https://bootstrap.pypa.io/get-pip.py" -O /tmp/get-pip.py \
     && python /tmp/get-pip.py \
-    && pip install awscli==1.11.25 \
+    && pip install awscli==1.11.108 \
     && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/* 
  
 

--- a/ubuntu/nodejs/4.4.7/Dockerfile
+++ b/ubuntu/nodejs/4.4.7/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update \
 
 RUN wget "https://bootstrap.pypa.io/get-pip.py" -O /tmp/get-pip.py \
     && python /tmp/get-pip.py \
-    && pip install awscli==1.11.108 \
+    && pip install awscli==1.11.112 \
     && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/* 
  
 

--- a/ubuntu/nodejs/4.4.7/Dockerfile
+++ b/ubuntu/nodejs/4.4.7/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update \
 
 RUN wget "https://bootstrap.pypa.io/get-pip.py" -O /tmp/get-pip.py \
     && python /tmp/get-pip.py \
-    && pip install awscli==1.11.25 \
+    && pip install awscli==1.11.108 \
     && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/* 
  
 

--- a/ubuntu/nodejs/5.12.0/Dockerfile
+++ b/ubuntu/nodejs/5.12.0/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update \
 
 RUN wget "https://bootstrap.pypa.io/get-pip.py" -O /tmp/get-pip.py \
     && python /tmp/get-pip.py \
-    && pip install awscli==1.11.108 \
+    && pip install awscli==1.11.112 \
     && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/* 
  
 

--- a/ubuntu/nodejs/5.12.0/Dockerfile
+++ b/ubuntu/nodejs/5.12.0/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update \
 
 RUN wget "https://bootstrap.pypa.io/get-pip.py" -O /tmp/get-pip.py \
     && python /tmp/get-pip.py \
-    && pip install awscli==1.11.25 \
+    && pip install awscli==1.11.108 \
     && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/* 
  
 

--- a/ubuntu/nodejs/6.3.1/Dockerfile
+++ b/ubuntu/nodejs/6.3.1/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update \
 
 RUN wget "https://bootstrap.pypa.io/get-pip.py" -O /tmp/get-pip.py \
     && python /tmp/get-pip.py \
-    && pip install awscli==1.11.108 \
+    && pip install awscli==1.11.112 \
     && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/* 
  
 

--- a/ubuntu/nodejs/6.3.1/Dockerfile
+++ b/ubuntu/nodejs/6.3.1/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update \
 
 RUN wget "https://bootstrap.pypa.io/get-pip.py" -O /tmp/get-pip.py \
     && python /tmp/get-pip.py \
-    && pip install awscli==1.11.25 \
+    && pip install awscli==1.11.108 \
     && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/* 
  
 

--- a/ubuntu/nodejs/7.0.0/Dockerfile
+++ b/ubuntu/nodejs/7.0.0/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update \
 
 RUN wget "https://bootstrap.pypa.io/get-pip.py" -O /tmp/get-pip.py \
     && python /tmp/get-pip.py \
-    && pip install awscli==1.11.108 \
+    && pip install awscli==1.11.112 \
     && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/* 
  
 

--- a/ubuntu/nodejs/7.0.0/Dockerfile
+++ b/ubuntu/nodejs/7.0.0/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update \
 
 RUN wget "https://bootstrap.pypa.io/get-pip.py" -O /tmp/get-pip.py \
     && python /tmp/get-pip.py \
-    && pip install awscli==1.11.25 \
+    && pip install awscli==1.11.108 \
     && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/* 
  
 

--- a/ubuntu/python/2.7.12/Dockerfile
+++ b/ubuntu/python/2.7.12/Dockerfile
@@ -80,7 +80,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
 # https://github.com/docker-library/python/pull/143#issuecomment-241032683
 	&& pip install --no-cache-dir --upgrade --force-reinstall "pip==$PYTHON_PIP_VERSION" \
-        && pip install awscli==1.11.25 --no-cache-dir \
+        && pip install awscli==1.11.108 --no-cache-dir \
 # then we use "pip list" to ensure we don't have more than one pip version installed
 # https://github.com/docker-library/python/pull/100
 	&& [ "$(pip list |tac|tac| awk -F '[ ()]+' '$1 == "pip" { print $2; exit }')" = "$PYTHON_PIP_VERSION" ] \

--- a/ubuntu/python/2.7.12/Dockerfile
+++ b/ubuntu/python/2.7.12/Dockerfile
@@ -80,7 +80,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
 # https://github.com/docker-library/python/pull/143#issuecomment-241032683
 	&& pip install --no-cache-dir --upgrade --force-reinstall "pip==$PYTHON_PIP_VERSION" \
-        && pip install awscli==1.11.108 --no-cache-dir \
+        && pip install awscli==1.11.112 --no-cache-dir \
 # then we use "pip list" to ensure we don't have more than one pip version installed
 # https://github.com/docker-library/python/pull/100
 	&& [ "$(pip list |tac|tac| awk -F '[ ()]+' '$1 == "pip" { print $2; exit }')" = "$PYTHON_PIP_VERSION" ] \

--- a/ubuntu/python/3.3.6/Dockerfile
+++ b/ubuntu/python/3.3.6/Dockerfile
@@ -83,7 +83,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
 # https://github.com/docker-library/python/pull/143#issuecomment-241032683
     && pip3 install --no-cache-dir --upgrade --force-reinstall "pip==$PYTHON_PIP_VERSION" \
-    && pip install awscli==1.11.25 --no-cache-dir \
+    && pip install awscli==1.11.108 --no-cache-dir \
 # then we use "pip list" to ensure we don't have more than one pip version installed
 # https://github.com/docker-library/python/pull/100
     && [ "$(pip list |tac|tac| awk -F '[ ()]+' '$1 == "pip" { print $2; exit }')" = "$PYTHON_PIP_VERSION" ] \

--- a/ubuntu/python/3.3.6/Dockerfile
+++ b/ubuntu/python/3.3.6/Dockerfile
@@ -83,7 +83,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
 # https://github.com/docker-library/python/pull/143#issuecomment-241032683
     && pip3 install --no-cache-dir --upgrade --force-reinstall "pip==$PYTHON_PIP_VERSION" \
-    && pip install awscli==1.11.108 --no-cache-dir \
+    && pip install awscli==1.11.112 --no-cache-dir \
 # then we use "pip list" to ensure we don't have more than one pip version installed
 # https://github.com/docker-library/python/pull/100
     && [ "$(pip list |tac|tac| awk -F '[ ()]+' '$1 == "pip" { print $2; exit }')" = "$PYTHON_PIP_VERSION" ] \

--- a/ubuntu/python/3.4.5/Dockerfile
+++ b/ubuntu/python/3.4.5/Dockerfile
@@ -83,7 +83,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
 # https://github.com/docker-library/python/pull/143#issuecomment-241032683
 	&& pip3 install --no-cache-dir --upgrade --force-reinstall "pip==$PYTHON_PIP_VERSION" \
-        && pip install awscli==1.11.25 --no-cache-dir \
+        && pip install awscli==1.11.108 --no-cache-dir \
 # then we use "pip list" to ensure we don't have more than one pip version installed
 # https://github.com/docker-library/python/pull/100
 	&& [ "$(pip list |tac|tac| awk -F '[ ()]+' '$1 == "pip" { print $2; exit }')" = "$PYTHON_PIP_VERSION" ] \

--- a/ubuntu/python/3.4.5/Dockerfile
+++ b/ubuntu/python/3.4.5/Dockerfile
@@ -83,7 +83,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
 # https://github.com/docker-library/python/pull/143#issuecomment-241032683
 	&& pip3 install --no-cache-dir --upgrade --force-reinstall "pip==$PYTHON_PIP_VERSION" \
-        && pip install awscli==1.11.108 --no-cache-dir \
+        && pip install awscli==1.11.112 --no-cache-dir \
 # then we use "pip list" to ensure we don't have more than one pip version installed
 # https://github.com/docker-library/python/pull/100
 	&& [ "$(pip list |tac|tac| awk -F '[ ()]+' '$1 == "pip" { print $2; exit }')" = "$PYTHON_PIP_VERSION" ] \

--- a/ubuntu/python/3.5.2/Dockerfile
+++ b/ubuntu/python/3.5.2/Dockerfile
@@ -83,7 +83,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
 # https://github.com/docker-library/python/pull/143#issuecomment-241032683
 	&& pip3 install --no-cache-dir --upgrade --force-reinstall "pip==$PYTHON_PIP_VERSION" \
-        && pip install awscli==1.11.25 --no-cache-dir \
+        && pip install awscli==1.11.108 --no-cache-dir \
 # then we use "pip list" to ensure we don't have more than one pip version installed
 # https://github.com/docker-library/python/pull/100
 	&& [ "$(pip list |tac|tac| awk -F '[ ()]+' '$1 == "pip" { print $2; exit }')" = "$PYTHON_PIP_VERSION" ] \

--- a/ubuntu/python/3.5.2/Dockerfile
+++ b/ubuntu/python/3.5.2/Dockerfile
@@ -83,7 +83,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
 # https://github.com/docker-library/python/pull/143#issuecomment-241032683
 	&& pip3 install --no-cache-dir --upgrade --force-reinstall "pip==$PYTHON_PIP_VERSION" \
-        && pip install awscli==1.11.108 --no-cache-dir \
+        && pip install awscli==1.11.112 --no-cache-dir \
 # then we use "pip list" to ensure we don't have more than one pip version installed
 # https://github.com/docker-library/python/pull/100
 	&& [ "$(pip list |tac|tac| awk -F '[ ()]+' '$1 == "pip" { print $2; exit }')" = "$PYTHON_PIP_VERSION" ] \

--- a/ubuntu/ruby/2.1.10/Dockerfile
+++ b/ubuntu/ruby/2.1.10/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update \
 
 RUN wget "https://bootstrap.pypa.io/get-pip.py" -O /tmp/get-pip.py \
     && python /tmp/get-pip.py \
-    && pip install awscli==1.11.108 \
+    && pip install awscli==1.11.112 \
     && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/* 
  
 

--- a/ubuntu/ruby/2.1.10/Dockerfile
+++ b/ubuntu/ruby/2.1.10/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update \
 
 RUN wget "https://bootstrap.pypa.io/get-pip.py" -O /tmp/get-pip.py \
     && python /tmp/get-pip.py \
-    && pip install awscli==1.11.25 \
+    && pip install awscli==1.11.108 \
     && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/* 
  
 

--- a/ubuntu/ruby/2.2.5/Dockerfile
+++ b/ubuntu/ruby/2.2.5/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update \
 
 RUN wget "https://bootstrap.pypa.io/get-pip.py" -O /tmp/get-pip.py \
     && python /tmp/get-pip.py \
-    && pip install awscli==1.11.108 \
+    && pip install awscli==1.11.112 \
     && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/* 
  
 

--- a/ubuntu/ruby/2.2.5/Dockerfile
+++ b/ubuntu/ruby/2.2.5/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update \
 
 RUN wget "https://bootstrap.pypa.io/get-pip.py" -O /tmp/get-pip.py \
     && python /tmp/get-pip.py \
-    && pip install awscli==1.11.25 \
+    && pip install awscli==1.11.108 \
     && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/* 
  
 

--- a/ubuntu/ruby/2.3.1/Dockerfile
+++ b/ubuntu/ruby/2.3.1/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update \
 
 RUN wget "https://bootstrap.pypa.io/get-pip.py" -O /tmp/get-pip.py \
     && python /tmp/get-pip.py \
-    && pip install awscli==1.11.108 \
+    && pip install awscli==1.11.112 \
     && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/* 
  
 

--- a/ubuntu/ruby/2.3.1/Dockerfile
+++ b/ubuntu/ruby/2.3.1/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update \
 
 RUN wget "https://bootstrap.pypa.io/get-pip.py" -O /tmp/get-pip.py \
     && python /tmp/get-pip.py \
-    && pip install awscli==1.11.25 \
+    && pip install awscli==1.11.108 \
     && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/* 
  
 

--- a/ubuntu/ubuntu-base/14.04/Dockerfile
+++ b/ubuntu/ubuntu-base/14.04/Dockerfile
@@ -29,5 +29,5 @@ RUN apt-get update \
 
 RUN wget "https://bootstrap.pypa.io/get-pip.py" -O /tmp/get-pip.py \
     && python /tmp/get-pip.py \
-    && pip install awscli==1.11.25 \
+    && pip install awscli==1.11.108 \
     && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/ubuntu/ubuntu-base/14.04/Dockerfile
+++ b/ubuntu/ubuntu-base/14.04/Dockerfile
@@ -29,5 +29,5 @@ RUN apt-get update \
 
 RUN wget "https://bootstrap.pypa.io/get-pip.py" -O /tmp/get-pip.py \
     && python /tmp/get-pip.py \
-    && pip install awscli==1.11.108 \
+    && pip install awscli==1.11.112 \
     && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
The `aws-cli` in all containers is starting to get out of date. I think it's time to update all of them to the latest version as of writing.

This is specifically a problem with the `docker/1.12.1` image. It doesn't support the `--no-include-email` flag when trying to login. This will start to become a problem as people try to migrate their `buildspec.yml` files to a future-proof state.

https://docs.docker.com/engine/deprecated/#e-and---email-flags-on-docker-login
https://github.com/aws/aws-cli/issues/1926