### PR TITLE
use Docker 17.09.0-ce

### DIFF
--- a/ubuntu/docker/17.09.0-ce/Dockerfile
+++ b/ubuntu/docker/17.09.0-ce/Dockerfile
@@ -1,0 +1,78 @@
+# Copyright 2017-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Amazon Software License (the "License"). You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#    http://aws.amazon.com/asl/
+#
+# or in the "license" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+#
+
+FROM ubuntu:14.04.5
+
+# Building git from source code:
+#   Ubuntu's default git package is built with broken gnutls. Rebuild git with openssl.
+##########################################################################
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       iptables libapparmor1 libsystemd-journal0 \
+       wget python python2.7-dev fakeroot ca-certificates tar gzip zip \
+       autoconf automake bzip2 file g++ gcc imagemagick libbz2-dev libc6-dev libcurl4-openssl-dev \
+       libdb-dev libevent-dev libffi-dev libgeoip-dev libglib2.0-dev libjpeg-dev libkrb5-dev \
+       liblzma-dev libmagickcore-dev libmagickwand-dev libmysqlclient-dev libncurses-dev libpng-dev \
+       libpq-dev libreadline-dev libsqlite3-dev libssl-dev libtool libwebp-dev libxml2-dev libxslt-dev \
+       libyaml-dev make patch xz-utils zlib1g-dev unzip curl \
+    && apt-get -qy build-dep git \
+    && apt-get -qy install libcurl4-openssl-dev git-man liberror-perl \
+    && mkdir -p /usr/src/git-openssl \
+    && cd /usr/src/git-openssl \
+    && apt-get source git \
+    && cd $(find -mindepth 1 -maxdepth 1 -type d -name "git-*") \
+    && sed -i -- 's/libcurl4-gnutls-dev/libcurl4-openssl-dev/' ./debian/control \
+    && sed -i -- '/TEST\s*=\s*test/d' ./debian/rules \
+    && dpkg-buildpackage -rfakeroot -b \
+    && find .. -type f -name "git_*ubuntu*.deb" -exec dpkg -i \{\} \; \
+    && rm -rf /usr/src/git-openssl \
+# Install dependencies by all python images equivalent to buildpack-deps:jessie
+# on the public repos.
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
+
+RUN wget "https://bootstrap.pypa.io/get-pip.py" -O /tmp/get-pip.py \
+    && python /tmp/get-pip.py \
+    && pip install awscli==1.11.180 \
+    && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/* 
+ 
+
+ENV DOCKER_VERSION="17.09.0" \
+    DOCKER_SHA256="e9902c16a81b67830bf361074e5ffc3333bf48a3e37e2ef0544fd9955bd3f1f7" \
+    DIND_COMMIT="52379fa76dee07ca038624d639d9e14f4fb719ff"
+
+COPY dockerd-entrypoint.sh /usr/local/bin/
+
+# From the docker:1.11
+RUN set -x \
+    # From the docker dind 1.11
+    && apt-get update && apt-get install -y --no-install-recommends \
+       e2fsprogs iptables xfsprogs xz-utils \
+    # install Docker from deb package
+    && curl -fSL "https://download.docker.com/linux/ubuntu/dists/trusty/pool/stable/amd64/docker-ce_${DOCKER_VERSION}~ce-0~ubuntu_amd64.deb" -o docker.deb \
+    && echo "${DOCKER_SHA256} *docker.deb" | sha256sum -c - \
+    && dpkg -i docker.deb \
+    && rm docker.deb \
+    && docker -v \
+# set up subuid/subgid so that "--userns-remap=default" works out-of-the-box
+    && addgroup dockremap \
+    && useradd -g dockremap dockremap \
+    && echo 'dockremap:165536:65536' >> /etc/subuid \
+    && echo 'dockremap:165536:65536' >> /etc/subgid \
+    && wget "https://raw.githubusercontent.com/moby/moby/${DIND_COMMIT}/hack/dind" -O /usr/local/bin/dind \
+    && chmod +x /usr/local/bin/dind \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
+
+VOLUME /var/lib/docker
+
+ENTRYPOINT ["dockerd-entrypoint.sh"]

--- a/ubuntu/docker/17.09.0-ce/dockerd-entrypoint.sh
+++ b/ubuntu/docker/17.09.0-ce/dockerd-entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -e
+
+/usr/bin/dockerd \
+	--host=unix:///var/run/docker.sock \
+	--host=tcp://0.0.0.0:2375 \
+	--storage-driver=overlay &>/var/log/docker.log &
+
+
+tries=0
+d_timeout=60
+until docker info >/dev/null 2>&1
+do
+	if [ "$tries" -gt "$d_timeout" ]; then
+                cat /var/log/docker.log
+		echo 'Timed out trying to connect to internal docker host.' >&2
+		exit 1
+	fi
+        tries=$(( $tries + 1 ))
+	sleep 1
+done
+
+eval "$@"

--- a/ubuntu/docker/17.09.0-ce/dockerd-entrypoint.sh
+++ b/ubuntu/docker/17.09.0-ce/dockerd-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-/usr/bin/dockerd \
+/usr/local/bin/dind dockerd \
 	--host=unix:///var/run/docker.sock \
 	--host=tcp://0.0.0.0:2375 \
 	--storage-driver=overlay &>/var/log/docker.log &


### PR DESCRIPTION
- uses Docker 17.09.0-ce
- switches to .deb because tarball download from get.docker.com is deprecated
- updates entrypoint to use dockerd
- updates dind script to point to newer commit and correct github repo (moby)