### PR TITLE
Add Node.js v8.9.3 Dockerfile

### DIFF
--- a/ubuntu/nodejs/8.9.3/Dockerfile
+++ b/ubuntu/nodejs/8.9.3/Dockerfile
@@ -1,0 +1,79 @@
+# Copyright 2017-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Amazon Software License (the "License"). You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#    http://aws.amazon.com/asl/
+#
+# or in the "license" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+#
+
+FROM ubuntu:14.04.5
+
+# Building git from source code:
+#   Ubuntu's default git package is built with broken gnutls. Rebuild git with openssl.
+##########################################################################
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       wget=1.15-* python=2.7.5-* python2.7-dev=2.7.6-* fakeroot=1.20-* ca-certificates \
+       tar=1.27.1-* gzip=1.6-* zip=3.0-* autoconf=2.69-* automake=1:1.14.1-* \
+       bzip2=1.0.6-* file=1:5.14-* g++=4:4.8.2-* gcc=4:4.8.2-* imagemagick=8:6.7.7.10-* \
+       libbz2-dev=1.0.6-* libc6-dev=2.19-* libcurl4-openssl-dev=7.35.0-* libdb-dev=1:5.3.21~* \
+       libevent-dev=2.0.21-stable-* libffi-dev=3.1~rc1+r3.0.13-* libgeoip-dev=1.6.0-* libglib2.0-dev=2.40.2-* \
+       libjpeg-dev=8c-* libkrb5-dev=1.12+dfsg-* liblzma-dev=5.1.1alpha+20120614-* \
+       libmagickcore-dev=8:6.7.7.10-* libmagickwand-dev=8:6.7.7.10-* libmysqlclient-dev=5.5.58-* \
+       libncurses5-dev=5.9+20140118-* libpng12-dev=1.2.50-* libpq-dev=9.3.20-* libreadline-dev=6.3-* \
+       libsqlite3-dev=3.8.2-* libssl-dev=1.0.1f-* libtool=2.4.2-* libwebp-dev=0.4.0-* \
+       libxml2-dev=2.9.1+dfsg1-* libxslt1-dev=1.1.28-* libyaml-dev=0.1.4-* make=3.81-* \
+       patch=2.7.1-* xz-utils=5.1.1alpha+20120614-* zlib1g-dev=1:1.2.8.dfsg-* unzip=6.0-* curl=7.35.0-* \
+    && apt-get install -y -qq less=458-* groff=1.22.2-* \
+    && apt-get -qy build-dep git=1:1.9.1 \
+    && apt-get -qy install libcurl4-openssl-dev=7.35.0-* git-man=1:1.9.1-* liberror-perl=0.17-* \
+    && mkdir -p /usr/src/git-openssl \
+    && cd /usr/src/git-openssl \
+    && apt-get source git=1:1.9.1 \
+    && cd $(find -mindepth 1 -maxdepth 1 -type d -name "git-*") \
+    && sed -i -- 's/libcurl4-gnutls-dev/libcurl4-openssl-dev/' ./debian/control \
+    && sed -i -- '/TEST\s*=\s*test/d' ./debian/rules \
+    && dpkg-buildpackage -rfakeroot -b \
+    && find .. -type f -name "git_*ubuntu*.deb" -exec dpkg -i \{\} \; \
+    && rm -rf /usr/src/git-openssl \
+# Install dependencies by all python images equivalent to buildpack-deps:jessie
+# on the public repos.
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
+
+RUN wget "https://bootstrap.pypa.io/get-pip.py" -O /tmp/get-pip.py \
+    && python /tmp/get-pip.py \
+    && pip install awscli==1.11.157 \
+    && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/* 
+ 
+
+ENV NODE_VERSION="8.9.3"
+
+RUN set -ex \
+    && for key in \
+      94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+      FD3A5288F042B6850C66B31F09FE44734EB7990E \
+      71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+      DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+      C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+      B9AE9905FFD7803F25714661B63B535A4C206CA9 \
+      56730D5401028683275BD23C23EFEFE93C4CFFFE \
+      77984A986EBC2AA786BC0F66B01FBB92821C587A \
+    ; do \
+      gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+    done
+
+RUN wget "https://nodejs.org/download/release/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" -O node-v$NODE_VERSION-linux-x64.tar.gz \
+	&& wget "https://nodejs.org/download/release/v$NODE_VERSION/SHASUMS256.txt.asc" -O SHASUMS256.txt.asc \
+	&& gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+	&& grep " node-v$NODE_VERSION-linux-x64.tar.gz\$" SHASUMS256.txt | sha256sum -c - \
+    && tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 \
+    && rm "node-v$NODE_VERSION-linux-x64.tar.gz" SHASUMS256.txt.asc SHASUMS256.txt \
+    && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
+    && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+CMD [ "node" ]


### PR DESCRIPTION
Add Node.js v 8.9.3 LTS (Carbon)
Dockerfile built from the included v 7.0.0
Updated signing keys

Updated to include the most recent update with Docker 17, updated CLI, etc.