### PR TITLE
bump libpq-dev version

### DIFF
--- a/ubuntu/python/2.7.12/Dockerfile
+++ b/ubuntu/python/2.7.12/Dockerfile
@@ -48,7 +48,7 @@ RUN apt-get update \
         libgeoip-dev=1.6.0-* libglib2.0-dev=2.40.2-* libjpeg-dev=8c-* \
         libkrb5-dev=1.12+dfsg-* liblzma-dev=5.1.1alpha+20120614-* libmagickcore-dev=8:6.7.7.10-* \
         libmagickwand-dev=8:6.7.7.10-* libmysqlclient-dev=5.5.59-* libncurses5-dev=5.9+20140118-* \
-        libpng12-dev=1.2.50-* libpq-dev=9.3.21-* libreadline-dev=6.3-* libsqlite3-dev=3.8.2-* \
+        libpng12-dev=1.2.50-* libpq-dev=9.3.22-* libreadline-dev=6.3-* libsqlite3-dev=3.8.2-* \
         libssl-dev=1.0.1f-* libtool=2.4.2-* libwebp-dev=0.4.0-* libxml2-dev=2.9.1+dfsg1-* \
         libxslt1-dev=1.1.28-* libyaml-dev=0.1.4-* make=3.81-* patch=2.7.1-* xz-utils=5.1.1alpha+20120614-* \
         zlib1g-dev=1:1.2.8.dfsg-* tcl=8.6.0+* tk=8.6.0+* ca-certificates \


### PR DESCRIPTION
libpq-dev 9.3.21-* is no longer available, bump to 9.3.22-*.