### PR TITLE
Add execution permissions to dep

### DIFF
--- a/ubuntu/golang/1.10/Dockerfile
+++ b/ubuntu/golang/1.10/Dockerfile
@@ -99,7 +99,8 @@ RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" \
     && echo "$GOLANG_DOWNLOAD_SHA256 /tmp/golang.tar.gz" | sha256sum -c - \
     && tar -xzf /tmp/golang.tar.gz -C /usr/local \
     && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-    && wget "https://github.com/golang/dep/releases/download/v$DEP_VERSION/$DEP_BINARY" -O "$GOPATH/bin/dep"
+    && wget "https://github.com/golang/dep/releases/download/v$DEP_VERSION/$DEP_BINARY" -O "$GOPATH/bin/dep" \
+    && chmod +x "$GOPATH/bin/dep"
 
 ENV PATH="$GOPATH/bin:/usr/local/go/bin:$PATH"
 WORKDIR $GOPATH

--- a/ubuntu/golang/1.7.3/Dockerfile
+++ b/ubuntu/golang/1.7.3/Dockerfile
@@ -99,7 +99,8 @@ RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" \
     && echo "$GOLANG_DOWNLOAD_SHA256 /tmp/golang.tar.gz" | sha256sum -c - \
     && tar -xzf /tmp/golang.tar.gz -C /usr/local \
     && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-    && wget "https://github.com/golang/dep/releases/download/v$DEP_VERSION/$DEP_BINARY" -O "$GOPATH/bin/dep"
+    && wget "https://github.com/golang/dep/releases/download/v$DEP_VERSION/$DEP_BINARY" -O "$GOPATH/bin/dep" \
+    && chmod +x "$GOPATH/bin/dep"
 
 ENV PATH="$GOPATH/bin:/usr/local/go/bin:$PATH"
 WORKDIR $GOPATH


### PR DESCRIPTION
Fixes #38
Changes:

- Add execution permissions to `dep` in `aws/codebuild/golang:1.7.3` image.
- Add execution permissions to `dep` in `aws/codebuild/golang:1.10` image.