### PR TITLE
Fix #47, updating package version for openjdk8.

### DIFF
--- a/ubuntu/java/openjdk-8/Dockerfile
+++ b/ubuntu/java/openjdk-8/Dockerfile
@@ -83,7 +83,7 @@ COPY dockerd-entrypoint.sh /usr/local/bin/
 
 ENV JAVA_VERSION=8 \
     JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64" \
-    JDK_VERSION="8u141-b15-3~14.04" \
+    JDK_VERSION="8u162-b12-1~14.04" \
     JDK_HOME="/usr/lib/jvm/java-8-openjdk-amd64" \
     JRE_HOME="/usr/lib/jvm/java-8-openjdk-amd64/jre" \
     ANT_VERSION=1.9.6 \


### PR DESCRIPTION
This fixes the build for the openjdk8 image. A new java build was done in the PPA a few days ago, see #47 