### PR TITLE
Update libmysqlclient-dev in ubuntu/docker/17.09.0

### DIFF
--- a/ubuntu/docker/17.09.0/Dockerfile
+++ b/ubuntu/docker/17.09.0/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update \
        libbz2-dev=1.0.6-* libc6-dev=2.19-* libcurl4-openssl-dev=7.35.0-* libdb-dev=1:5.3.21~* \
        libevent-dev=2.0.21-stable-* libffi-dev=3.1~rc1+r3.0.13-* libgeoip-dev=1.6.0-* libglib2.0-dev=2.40.2-* \
        libjpeg-dev=8c-* libkrb5-dev=1.12+dfsg-* liblzma-dev=5.1.1alpha+20120614-* \
-       libmagickcore-dev=8:6.7.7.10-* libmagickwand-dev=8:6.7.7.10-* libmysqlclient-dev=5.5.59-* \
+       libmagickcore-dev=8:6.7.7.10-* libmagickwand-dev=8:6.7.7.10-* libmysqlclient-dev=5.5.60-* \
        libncurses5-dev=5.9+20140118-* libpng12-dev=1.2.50-* libpq-dev=9.3.22-* libreadline-dev=6.3-* \
        libsqlite3-dev=3.8.2-* libssl-dev=1.0.1f-* libtool=2.4.2-* libwebp-dev=0.4.0-* \
        libxml2-dev=2.9.1+dfsg1-* libxslt1-dev=1.1.28-* libyaml-dev=0.1.4-* make=3.81-* \


### PR DESCRIPTION
*Description of changes:*
* Update libmysqlclient-dev in ubuntu/docker/17.09.0 to libmysqlclient-dev=5.5.60-*. libmysqlclient-dev=5.5.59-* is not available anymore and causes the docker build to fail.

Haven't tested this beyond getting it to build.

*To Reproduce*
```
cd ubuntu/docker/17.09.0
docker build -t codebuild .

# should fail with:
# E: Version '5.5.59-*' for 'libmysqlclient-dev' was not found
```


