### PR TITLE
Fixes broken python dockerfiles

### DIFF
--- a/ubuntu/python/3.5.2/Dockerfile
+++ b/ubuntu/python/3.5.2/Dockerfile
@@ -102,12 +102,9 @@ RUN set -ex \
     \
     && wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
 	&& wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \
-	&& export GNUPGHOME="$(mktemp -d)" \
-	&& (gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$GPG_KEY" \
-        || gpg --keyserver pgp.mit.edu --recv-keys "$GPG_KEY" \
-        || gpg --keyserver keyserver.ubuntu.com --recv-keys "$GPG_KEY") \
+	&& wget https://www.python.org/static/files/pubkeys.txt \
+    && gpg --import pubkeys.txt \
 	&& gpg --batch --verify python.tar.xz.asc python.tar.xz \
-	&& rm -r "$GNUPGHOME" python.tar.xz.asc \
 	&& mkdir -p /usr/src/python \
 	&& tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
 	&& rm python.tar.xz \

--- a/ubuntu/python/3.6.5/Dockerfile
+++ b/ubuntu/python/3.6.5/Dockerfile
@@ -153,4 +153,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 CMD ["python3"]
 
-#ENTRYPOINT ["dockerd-entrypoint.sh"]
+ENTRYPOINT ["dockerd-entrypoint.sh"]

--- a/ubuntu/python/3.6.5/Dockerfile
+++ b/ubuntu/python/3.6.5/Dockerfile
@@ -104,9 +104,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
 	&& wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \
 	&& export GNUPGHOME="$(mktemp -d)" \
-	&& (gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$GPG_KEY" \
-        || gpg --keyserver pgp.mit.edu --recv-keys "$GPG_KEY" \
-        || gpg --keyserver keyserver.ubuntu.com --recv-keys "$GPG_KEY") \
+    && wget https://www.python.org/static/files/pubkeys.txt \
+    && gpg --import pubkeys.txt \
 	&& gpg --batch --verify python.tar.xz.asc python.tar.xz \
 	&& rm -r "$GNUPGHOME" python.tar.xz.asc \
 	&& mkdir -p /usr/src/python \
@@ -154,4 +153,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 CMD ["python3"]
 
-ENTRYPOINT ["dockerd-entrypoint.sh"]
+#ENTRYPOINT ["dockerd-entrypoint.sh"]


### PR DESCRIPTION
*Issue #, if available:*
None
*Description of changes:*
This fixes the download of gpg key to validate python download. I replaced it with a better method that will not break if the key SHA is changed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
