### PR TITLE
update openjdk8 version to 8u171-b11-2

### DIFF
--- a/ubuntu/java/openjdk-8/Dockerfile
+++ b/ubuntu/java/openjdk-8/Dockerfile
@@ -96,7 +96,7 @@ COPY dockerd-entrypoint.sh /usr/local/bin/
 
 ENV JAVA_VERSION=8 \
     JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64" \
-    JDK_VERSION="8u162-b12-1~14.04" \
+    JDK_VERSION="8u171-b11-2~14.04" \
     JDK_HOME="/usr/lib/jvm/java-8-openjdk-amd64" \
     JRE_HOME="/usr/lib/jvm/java-8-openjdk-amd64/jre" \
     ANT_VERSION=1.9.6 \


### PR DESCRIPTION
Attempting to build this image currently produces the error:

> E: Version '8u162-b12-1~14.04' for 'openjdk-8-jdk' was not found

Looks like the ubuntu version of java8 has been updated again. This has happened before in issue #47.

This PR updates the openjdk to the availabile build version stated here: https://launchpad.net/~openjdk-r/+archive/ubuntu/ppa

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
