### PR TITLE
Added .NET Core 2.1 image

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The following images are actively maintained by AWS CodeBuild, and are listed in
 + [docker 17.09.0](ubuntu/docker/17.09.0)
 + [dot-net core-1](ubuntu/dot-net/core-1)
 + [dot-net core-2](ubuntu/dot-net/core-2)
++ [dot-net core-2.1](ubuntu/dot-net/core-2.1)
 + [golang 1.10](ubuntu/golang/1.10)
 + [java openjdk-8](ubuntu/java/openjdk-8)
 + [java openjdk-9](ubuntu/java/openjdk-9)

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -13,6 +13,8 @@ phases:
       - docker build -t aws/codebuild/dot-net:core-1 .
       - cd $CODEBUILD_SRC_DIR/ubuntu/dot-net/core-2
       - docker build -t aws/codebuild/dot-net:core-2 .
+      - cd $CODEBUILD_SRC_DIR/ubuntu/dot-net/core-2.1
+      - docker build -t aws/codebuild/dot-net:core-2.1 .
       - cd $CODEBUILD_SRC_DIR/ubuntu/golang/1.10
       - docker build -t aws/codebuild/golang:1.10 .
       - cd $CODEBUILD_SRC_DIR/ubuntu/java/openjdk-8

--- a/ubuntu/dot-net/core-2.1/Dockerfile
+++ b/ubuntu/dot-net/core-2.1/Dockerfile
@@ -1,0 +1,138 @@
+# Copyright 2017-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Amazon Software License (the "License"). You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#    http://aws.amazon.com/asl/
+#
+# or in the "license" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+#
+
+FROM ubuntu:14.04.5
+
+ENV DOCKER_BUCKET="download.docker.com" \
+    DOCKER_VERSION="17.09.0-ce" \
+    DOCKER_CHANNEL="stable" \
+    DOCKER_SHA256="a9e90a73c3cdfbf238f148e1ec0eaff5eb181f92f35bdd938fd7dab18e1c4647" \
+    DIND_COMMIT="3b5fac462d21ca164b3778647420016315289034" \
+    DOCKER_COMPOSE_VERSION="1.16.1" \
+    GITVERSION_VERSION="3.6.5"
+
+# Building git from source code:
+#   Ubuntu's default git package is built with broken gnutls. Rebuild git with openssl.
+##########################################################################
+RUN set -ex \
+    && echo 'Acquire::CompressionTypes::Order:: "gz";' > /etc/apt/apt.conf.d/99use-gzip-compression \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+       wget=1.15-* python=2.7.5-* python2.7-dev=2.7.6-* fakeroot=1.20-* ca-certificates \
+       tar=1.27.1-* gzip=1.6-* zip=3.0-* autoconf=2.69-* automake=1:1.14.1-* \
+       bzip2=1.0.6-* file=1:5.14-* g++=4:4.8.2-* gcc=4:4.8.2-* imagemagick=8:6.7.7.10-* \
+       libbz2-dev=1.0.6-* libc6-dev=2.19-* libcurl4-openssl-dev=7.35.0-* libdb-dev=1:5.3.21~* \
+       libevent-dev=2.0.21-stable-* libffi-dev=3.1~rc1+r3.0.13-* libgeoip-dev=1.6.0-* libglib2.0-dev=2.40.2-* \
+       libjpeg-dev=8c-* libkrb5-dev=1.12+dfsg-* liblzma-dev=5.1.1alpha+20120614-* \
+       libmagickcore-dev=8:6.7.7.10-* libmagickwand-dev=8:6.7.7.10-* libmysqlclient-dev=5.5.60-* \
+       libncurses5-dev=5.9+20140118-* libpng12-dev=1.2.50-* libpq-dev=9.3.22-* libreadline-dev=6.3-* \
+       libsqlite3-dev=3.8.2-* libssl-dev=1.0.1f-* libtool=2.4.2-* libwebp-dev=0.4.0-* \
+       libxml2-dev=2.9.1+dfsg1-* libxslt1-dev=1.1.28-* libyaml-dev=0.1.4-* make=3.81-* \
+       patch=2.7.1-* xz-utils=5.1.1alpha+20120614-* zlib1g-dev=1:1.2.8.dfsg-* unzip=6.0-* curl=7.35.0-* \
+       e2fsprogs=1.42.9-* iptables=1.4.21-* xfsprogs=3.1.9ubuntu2 xz-utils=5.1.1alpha+20120614-* \
+       mono-mcs=3.2.8+dfsg-* \
+    && apt-get install -y -qq less=458-* groff=1.22.2-* \
+    && apt-get -qy build-dep git=1:1.9.1 \
+    && apt-get -qy install libcurl4-openssl-dev=7.35.0-* git-man=1:1.9.1-* liberror-perl=0.17-* \
+    && mkdir -p /usr/src/git-openssl \
+    && cd /usr/src/git-openssl \
+    && apt-get source git=1:1.9.1 \
+    && cd $(find -mindepth 1 -maxdepth 1 -type d -name "git-*") \
+    && sed -i -- 's/libcurl4-gnutls-dev/libcurl4-openssl-dev/' ./debian/control \
+    && sed -i -- '/TEST\s*=\s*test/d' ./debian/rules \
+    && dpkg-buildpackage -rfakeroot -b \
+    && find .. -type f -name "git_*ubuntu*.deb" -exec dpkg -i \{\} \; \
+    && rm -rf /usr/src/git-openssl \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
+
+# Download and set up GitVersion
+RUN set -ex \
+    && wget "https://github.com/GitTools/GitVersion/releases/download/v${GITVERSION_VERSION}/GitVersion_${GITVERSION_VERSION}.zip" -O /tmp/GitVersion_${GITVERSION_VERSION}.zip \
+    && mkdir -p /usr/local/GitVersion_${GITVERSION_VERSION} \
+    && unzip /tmp/GitVersion_${GITVERSION_VERSION}.zip -d /usr/local/GitVersion_${GITVERSION_VERSION} \
+    && rm /tmp/GitVersion_${GITVERSION_VERSION}.zip \
+    && echo "mono /usr/local/GitVersion_${GITVERSION_VERSION}/GitVersion.exe /output json /showvariable \$1" >> /usr/local/bin/gitversion \
+    && chmod +x /usr/local/bin/gitversion
+# Install Docker
+RUN set -ex \
+    && curl -fSL "https://${DOCKER_BUCKET}/linux/static/${DOCKER_CHANNEL}/x86_64/docker-${DOCKER_VERSION}.tgz" -o docker.tgz \
+    && echo "${DOCKER_SHA256} *docker.tgz" | sha256sum -c - \
+    && tar --extract --file docker.tgz --strip-components 1  --directory /usr/local/bin/ \
+    && rm docker.tgz \
+    && docker -v \
+# set up subuid/subgid so that "--userns-remap=default" works out-of-the-box
+    && addgroup dockremap \
+    && useradd -g dockremap dockremap \
+    && echo 'dockremap:165536:65536' >> /etc/subuid \
+    && echo 'dockremap:165536:65536' >> /etc/subgid \
+    && wget "https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hack/dind" -O /usr/local/bin/dind \
+    && curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-Linux-x86_64 > /usr/local/bin/docker-compose \
+    && chmod +x /usr/local/bin/dind /usr/local/bin/docker-compose \
+# Ensure docker-compose works
+    && docker-compose version
+
+# Install dependencies by all python images equivalent to buildpack-deps:jessie
+# on the public repos.
+
+RUN set -ex \
+    && wget "https://bootstrap.pypa.io/2.6/get-pip.py" -O /tmp/get-pip.py \
+    && python /tmp/get-pip.py \
+    && pip install awscli \
+    && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+VOLUME /var/lib/docker
+
+COPY dockerd-entrypoint.sh /usr/local/bin/
+
+# Install .NET CLI dependencies
+RUN set -ex \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libc6=2.19-* \
+        libcurl3=7.35.0-* \
+        libgcc1=1:4.9.3-* \
+        libgssapi-krb5-2=1.12+dfsg-* \
+        libicu52=52.1-* \
+        liblttng-ust0=2.4.0-* \
+        libssl1.0.0=1.0.1f-* \
+        libunwind8=1.1-* \
+        libuuid1=2.20.1-* \
+        zlib1g=1:1.2.8.dfsg-* \
+        software-properties-common=0.92.37.8 \
+    && add-apt-repository ppa:ubuntu-toolchain-r/test -y \
+    && apt-get update \
+    && apt-get install -y libstdc++6=8-*\
+    && rm -rf /var/lib/apt/lists/*
+
+# Install .NET Core SDK
+ENV DOTNET_SDK_VERSION 2.1.300
+ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-x64.tar.gz
+ENV DOTNET_SDK_DOWNLOAD_SHA 80a6bfb1db5862804e90f819c1adeebe3d624eae0d6147e5d6694333f0458afd7d34ce73623964752971495a310ff7fcc266030ce5aef82d5de7293d94d13770
+
+RUN set -ex \
+    && curl -SL $DOTNET_SDK_DOWNLOAD_URL --output dotnet.tar.gz \
+    && echo "$DOTNET_SDK_DOWNLOAD_SHA dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
+
+# Trigger the population of the local package cache
+ENV NUGET_XMLDOC_MODE skip
+RUN set -ex \
+    && mkdir warmup \
+    && cd warmup \
+    && dotnet new \
+    && cd .. \
+    && rm -rf warmup \
+    && rm -rf /tmp/NuGetScratch

--- a/ubuntu/dot-net/core-2.1/dockerd-entrypoint.sh
+++ b/ubuntu/dot-net/core-2.1/dockerd-entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -e
+
+/usr/local/bin/dockerd \
+	--host=unix:///var/run/docker.sock \
+	--host=tcp://127.0.0.1:2375 \
+	--storage-driver=overlay &>/var/log/docker.log &
+
+
+tries=0
+d_timeout=60
+until docker info >/dev/null 2>&1
+do
+	if [ "$tries" -gt "$d_timeout" ]; then
+                cat /var/log/docker.log
+		echo 'Timed out trying to connect to internal docker host.' >&2
+		exit 1
+	fi
+        tries=$(( $tries + 1 ))
+	sleep 1
+done
+
+eval "$@"


### PR DESCRIPTION
Based on the existing 2.0 image, just pointing to the new SDK with updated hash.

*Issue #, if available:*  
#79 

*Description of changes:*
Add support for .NET Core 2.1. The only difference between this the current 2.0 Dockerfile is the new .NET SDK version and updating the associated hash.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.