### PR TITLE
Updating to libpq-dev-9.3.23.

### DIFF
--- a/ubuntu/golang/1.10/Dockerfile
+++ b/ubuntu/golang/1.10/Dockerfile
@@ -34,7 +34,7 @@ RUN set -ex \
        libevent-dev=2.0.21-stable-* libffi-dev=3.1~rc1+r3.0.13-* libgeoip-dev=1.6.0-* libglib2.0-dev=2.40.2-* \
        libjpeg-dev=8c-* libkrb5-dev=1.12+dfsg-* liblzma-dev=5.1.1alpha+20120614-* \
        libmagickcore-dev=8:6.7.7.10-* libmagickwand-dev=8:6.7.7.10-* libmysqlclient-dev=5.5.60-* \
-       libncurses5-dev=5.9+20140118-* libpng12-dev=1.2.50-* libpq-dev=9.3.22-* libreadline-dev=6.3-* \
+       libncurses5-dev=5.9+20140118-* libpng12-dev=1.2.50-* libpq-dev=9.3.23-* libreadline-dev=6.3-* \
        libsqlite3-dev=3.8.2-* libssl-dev=1.0.1f-* libtool=2.4.2-* libwebp-dev=0.4.0-* \
        libxml2-dev=2.9.1+dfsg1-* libxslt1-dev=1.1.28-* libyaml-dev=0.1.4-* make=3.81-* \
        patch=2.7.1-* xz-utils=5.1.1alpha+20120614-* zlib1g-dev=1:1.2.8.dfsg-* unzip=6.0-* curl=7.35.0-* \


### PR DESCRIPTION
*Description of changes:*
When trying to build the Docker image locally (with latest branch), I get the following message:

> The following packages have unmet dependencies:
 libpq-dev : Depends: libpq5 (= 9.3.22-0ubuntu0.14.04) but 9.3.23-0ubuntu0.14.04 is to be installed
E: Unable to correct problems, you have held broken packages.

Updating `libpq-dev-9.3.22` to `libpq-dev-9.3.23` solved the issue and the Docker image can now be built locally.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
