### PR TITLE
Turn on NPM's unsafe-perm setting

### DIFF
--- a/ubuntu/nodejs/10.1.0/Dockerfile
+++ b/ubuntu/nodejs/10.1.0/Dockerfile
@@ -122,4 +122,6 @@ RUN set -ex \
 		&& ln -s /usr/local/bin/node /usr/local/bin/nodejs \
 		&& rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+RUN npm set unsafe-perm true
+
 CMD [ "node" ]

--- a/ubuntu/nodejs/6.3.1/Dockerfile
+++ b/ubuntu/nodejs/6.3.1/Dockerfile
@@ -122,4 +122,6 @@ RUN set -ex \
     && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
     && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+RUN npm set unsafe-perm true
+
 CMD [ "node" ]

--- a/ubuntu/nodejs/8.11.0/Dockerfile
+++ b/ubuntu/nodejs/8.11.0/Dockerfile
@@ -122,4 +122,6 @@ RUN set -ex \
 		&& ln -s /usr/local/bin/node /usr/local/bin/nodejs \
 		&& rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+RUN npm set unsafe-perm true
+
 CMD [ "node" ]


### PR DESCRIPTION
Since CodeBuild executes all commands as root, it makes things easier and
less surprising to users if unsafe-perm is enabled in ~/.npmrc, as otherwise
npm may have surprising behavior, in particular around running `npm pack`
and similar commands, which will emit a warning that scripts will not be run
if unsafe-perm is not set, and proceed to return as if everything was
successfully done.

*Description of changes:* Enables `unsafe-perm` NPM setting, which allows executing a number of commands as `root` without possibly surprising behavior.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
