### PR TITLE
Issue 121: Fixing an issue with spaces in environment variables file path

### DIFF
--- a/local_builds/codebuild_build.sh
+++ b/local_builds/codebuild_build.sh
@@ -79,7 +79,10 @@ fi
 
 if [ -n "$environment_variable_file" ]
 then
-    docker_command+=" -v $(dirname $(allOSRealPath $environment_variable_file)):/LocalBuild/envFile/ -e \"ENV_VAR_FILE=$(basename $environment_variable_file)\""
+    environment_variable_file_path=$(allOSRealPath "$environment_variable_file")
+    environment_variable_file_dir=$(dirname "$environment_variable_file_path")
+    environment_variable_file_basename=$(basename "$environment_variable_file")
+    docker_command+=" -v \"$environment_variable_file_dir:/LocalBuild/envFile/\" -e \"ENV_VAR_FILE=$environment_variable_file_basename\""
 fi
 
 if  $awsconfig_flag


### PR DESCRIPTION
*Issue #, if available:*
* [Issue 121](https://github.com/aws/aws-codebuild-docker-images/issues/121)
* This change fixes an issue with environment variables file path containing spaces (e.g. if you store files in a "/Users/user/Google Drive/project" directory).

*Description of changes:*
* Encapsulating paths in quotes, so that spaces are correctly parsed

*Testing:*
I tested it locally and it works with both
* Absolute path for the environment variables, e.g. "/Users/user1/Google Drive/project/vars.env"
* Relative path, e.g. "vars.env" (will correctly resolve the working directory to absolute path even if it has spaces)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
