### PR TITLE
GNU Makefile so that all images can be built by typing, for example, make ruby/2.3.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+BUILDS=$(shell egrep -o 'ubuntu/[^ ]*' buildspec.yml | sed -r 's|^ubuntu/||')
+NAME=$(shell dirname $@)
+VERSION=$(shell basename $@)
+TAG=aws/codebuild/$(NAME):$(VERSION)
+
+$(BUILDS):
+	cd ubuntu/$(NAME)/$(VERSION) && \
+	docker build -t $(TAG) .

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BUILDS=$(shell egrep -o 'ubuntu/[^ ]*' buildspec.yml | sed -r 's|^ubuntu/||')
+BUILDS=$(shell egrep -o 'ubuntu/[^ ]*' buildspec.yml | sed 's|^ubuntu/||')
 NAME=$(shell dirname $@)
 VERSION=$(shell basename $@)
 TAG=aws/codebuild/$(NAME):$(VERSION)

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ NAME=$(shell dirname $@)
 VERSION=$(shell basename $@)
 TAG=aws/codebuild/$(NAME):$(VERSION)
 
+all: $(BUILDS)
+
 $(BUILDS):
 	cd ubuntu/$(NAME)/$(VERSION) && \
 	docker build -t $(TAG) .

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Steps to build Ruby 2.3.1 image
 * Run `cd ubuntu/ruby/2.3.1` to change the directory in your local workspace. This is the location of the Ruby 2.3.1 Dockerfile with Ubuntu 14.04 base.
 * Run `docker build -t aws/codebuild/ruby:2.3.1 .` to build Docker image locally
 
+Alternatively, you may use GNU make to build the above image:
+
+* Run `make ruby/2.3.1`. This will build the Docker image locally, as above, from a computer with GNU make.
+
 To poke around in the image interactively, build it and run:
 `docker run -it --entrypoint sh aws/codebuild/ruby:2.3.1 -c bash`
 


### PR DESCRIPTION
*Description of changes:*
This change introduces a GNU Makefile so that users of this repository can build all docker images locally by typing `make` or a particular image by typing a command like `make ruby/2.3.1`. I did this for myself as the Linux-based computer that I need to run build testing from can't run the buildspec.yml file, but it can run a Makefile no sweat.

The Makefile rather haphazardly pulls from the `buildspec.yaml` to obtain the list of build targets. I implemented an additional `all` target which allows a user to build all of the images in one shot if they feel the need. The user could also potentially speed up their build by typing `make all -j NUMCONCURRENTBUILDS`, but I can't support that claim with any data - it's just an interesting observation of mine.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
