### PR TITLE
update dotnet core sdk to 2.1.5

### DIFF
--- a/ubuntu/dot-net/core-2.1/Dockerfile
+++ b/ubuntu/dot-net/core-2.1/Dockerfile
@@ -122,9 +122,9 @@ RUN set -ex \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.1.402
+ENV DOTNET_SDK_VERSION 2.1.403
 ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-x64.tar.gz
-ENV DOTNET_SDK_DOWNLOAD_SHA dd7f15a8202ffa2a435b7289865af4483bb0f642ffcf98a1eb10464cb9c51dd1d771efbb6120f129fe9666f62707ba0b7c476cf1fd3536d3a29329f07456de48
+ENV DOTNET_SDK_DOWNLOAD_SHA 903a8a633aea9211ba36232a2decb3b34a59bb62bc145a0e7a90ca46dd37bb6c2da02bcbe2c50c17e08cdff8e48605c0f990786faf1f06be1ea4a4d373beb8a9
 
 RUN set -ex \
     && curl -SL $DOTNET_SDK_DOWNLOAD_URL --output dotnet.tar.gz \


### PR DESCRIPTION
*Issue #, if available:*
#146
*Description of changes:*
Lambda supports 2.1.5 now however with codebuild I am unable to rest my unit tests since I am using 2.1.5.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
