### PR TITLE
Adding jq to the base image for nodejs

### DIFF
--- a/ubuntu/nodejs/8.11.0/Dockerfile
+++ b/ubuntu/nodejs/8.11.0/Dockerfile
@@ -41,7 +41,7 @@ RUN set -ex \
     && chmod 600 ~/.ssh/known_hosts \
     && apt-get install -y --no-install-recommends \
        wget=1.15-* python=2.7.* python2.7-dev=2.7.* fakeroot=1.20-* ca-certificates \
-       tar=1.27.* gzip=1.6-* zip=3.0-* autoconf=2.69-* automake=1:1.14.* \
+       tar=1.27.* gzip=1.6-* zip=3.0-* jq=1.3-1.1ubuntu1.1 autoconf=2.69-* automake=1:1.14.* \
        bzip2=1.0.* file=1:5.14-* g++=4:4.8.* gcc=4:4.8.* imagemagick=8:6.7.* \
        libbz2-dev=1.0.* libc6-dev=2.19-* libcurl4-openssl-dev=7.35.* libdb-dev=1:5.3.* \
        libevent-dev=2.0.* libffi-dev=3.1~* libgeoip-dev=1.6.* libglib2.0-dev=2.40.* \


### PR DESCRIPTION
Adding the stable version for jq in ubuntu 14.04 LTS. It's not a very big package and plus it enhances a lot of things that the command line arguments in buildspec can do with json objects.
Feel free to use this contribution in any way it sees fit.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
