### PR TITLE
Fix python build failure on Mac

### DIFF
--- a/ubuntu/python/3.7.1/Dockerfile
+++ b/ubuntu/python/3.7.1/Dockerfile
@@ -132,7 +132,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
 	&& wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \
 	&& export GNUPGHOME="$(mktemp -d)" \
-	&& (gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$GPG_KEY" \
+	&& (gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$GPG_KEY" \
         || gpg --keyserver pgp.mit.edu --recv-keys "$GPG_KEY" \
         || gpg --keyserver keyserver.ubuntu.com --recv-keys "$GPG_KEY") \
 	&& gpg --batch --verify python.tar.xz.asc python.tar.xz \


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-codebuild-docker-images/issues/169

*Description of changes:*

Python 3.7.1 is not able to build on MacOS due to the keyserver timed out. I have tested this change against both MacOS and Linux. It should be backwards compatible.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
