### PR TITLE
Update Go 1.11 image to 1.11.6

### DIFF
--- a/ubuntu/golang/1.11/Dockerfile
+++ b/ubuntu/golang/1.11/Dockerfile
@@ -102,10 +102,10 @@ COPY ssh_config /root/.ssh/config
 
 COPY dockerd-entrypoint.sh /usr/local/bin/
 
-ENV GOLANG_VERSION="1.11.6" \
-    GOLANG_DOWNLOAD_SHA256="4e1864282d8d20010d6385a12a1e35641783a380a7c57907bfb46a5499c5eb49" \
+ENV GOLANG_VERSION="1.11.3" \
+    GOLANG_DOWNLOAD_SHA256="d20a4869ffb13cee0f7ee777bf18c7b9b67ef0375f93fac1298519e0c227a07f" \
     GOPATH="/go" \
-    DEP_VERSION="0.5.1" \
+    DEP_VERSION="0.5.0" \
     DEP_BINARY="dep-linux-amd64"
 
 RUN set -ex \

--- a/ubuntu/golang/1.11/Dockerfile
+++ b/ubuntu/golang/1.11/Dockerfile
@@ -102,10 +102,10 @@ COPY ssh_config /root/.ssh/config
 
 COPY dockerd-entrypoint.sh /usr/local/bin/
 
-ENV GOLANG_VERSION="1.11.3" \
-    GOLANG_DOWNLOAD_SHA256="d20a4869ffb13cee0f7ee777bf18c7b9b67ef0375f93fac1298519e0c227a07f" \
+ENV GOLANG_VERSION="1.11.6" \
+    GOLANG_DOWNLOAD_SHA256="4e1864282d8d20010d6385a12a1e35641783a380a7c57907bfb46a5499c5eb49" \
     GOPATH="/go" \
-    DEP_VERSION="0.5.0" \
+    DEP_VERSION="0.5.1" \
     DEP_BINARY="dep-linux-amd64"
 
 RUN set -ex \

--- a/ubuntu/standard/1.0/Dockerfile
+++ b/ubuntu/standard/1.0/Dockerfile
@@ -17,7 +17,7 @@ ENV RUBY_MAJOR="2.6" \
  NODE_VERSION="10.15.0" \
  NODE_8_VERSION="8.11.0" \
  NVM_VERSION="0.33.5" \
- GOLANG_VERSION="1.11.4" \
+ GOLANG_VERSION="1.11.6" \
  DOTNET_SDK_VERSION="2.2.102" \
  DOCKER_VERSION="18.09.1" \
  DOCKER_COMPOSE_VERSION="1.23.2"
@@ -442,9 +442,9 @@ RUN set -ex \
 #****************     END JAVA     ****************************************************
 
 #****************     GO     **********************************************************
-ENV GOLANG_DOWNLOAD_SHA256="fb26c30e6a04ad937bbc657a1b5bba92f80096af1e8ee6da6430c045a8db3a5b" \
+ENV GOLANG_DOWNLOAD_SHA256="d20a4869ffb13cee0f7ee777bf18c7b9b67ef0375f93fac1298519e0c227a07f" \
     GOPATH="/go" \
-    DEP_VERSION="0.5.0" \
+    DEP_VERSION="0.5.1" \
     DEP_BINARY="dep-linux-amd64"
 
 RUN set -ex \


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
This change bumps Golang 1.11 and dep to the newest minor versions.

Golang 1.11.4 contains an important fix for go modules checksum mismatches. Projects with symlinks or dependencies with symlinks produce different checksums in the go.sum file, which causes codebuild to fail if such a symlink exists and the checksum file is generated on a system other than linux.

Building the docker image is successful and my project now builds successfully in this new image.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
