### PR TITLE
Added a new image; Go 1.12.2

### DIFF
--- a/ubuntu/golang/1.12/Dockerfile
+++ b/ubuntu/golang/1.12/Dockerfile
@@ -1,0 +1,126 @@
+# Copyright 2017-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Amazon Software License (the "License"). You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#    http://aws.amazon.com/asl/
+#
+# or in the "license" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+#
+
+FROM ubuntu:14.04.5
+
+ENV DOCKER_BUCKET="download.docker.com" \
+    DOCKER_VERSION="18.09.0" \
+    DOCKER_CHANNEL="stable" \
+    DOCKER_SHA256="08795696e852328d66753963249f4396af2295a7fe2847b839f7102e25e47cb9" \
+    DIND_COMMIT="3b5fac462d21ca164b3778647420016315289034" \
+    DOCKER_COMPOSE_VERSION="1.23.2" \
+    GITVERSION_VERSION="3.6.5"
+
+# Install git, SSH, and other utilities
+RUN set -ex \
+    && echo 'Acquire::CompressionTypes::Order:: "gz";' > /etc/apt/apt.conf.d/99use-gzip-compression \
+    && apt-get update \
+    && apt install -y apt-transport-https \
+    && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
+    && echo "deb https://download.mono-project.com/repo/ubuntu stable-trusty main" | tee /etc/apt/sources.list.d/mono-official-stable.list \
+    && apt-get update \
+    && apt-get install software-properties-common -y --no-install-recommends \
+    && apt-add-repository ppa:git-core/ppa \
+    && apt-get update \
+    && apt-get install git=1:2.* -y --no-install-recommends \
+    && git version \
+    && apt-get install -y --no-install-recommends openssh-client=1:6.6* \
+    && mkdir ~/.ssh \
+    && touch ~/.ssh/known_hosts \
+    && ssh-keyscan -t rsa,dsa -H github.com >> ~/.ssh/known_hosts \
+    && ssh-keyscan -t rsa,dsa -H bitbucket.org >> ~/.ssh/known_hosts \
+    && chmod 600 ~/.ssh/known_hosts \
+    && apt-get install -y --no-install-recommends \
+       wget=1.15-* python3=3.4.* python3.4-dev=3.4.* fakeroot=1.20-* ca-certificates jq \
+       tar=1.27.* gzip=1.6-* zip=3.0-* autoconf=2.69-* automake=1:1.14.* \
+       bzip2=1.0.* file=1:5.14-* g++=4:4.8.* gcc=4:4.8.* imagemagick=8:6.7.* \
+       libbz2-dev=1.0.* libc6-dev=2.19-* libcurl4-openssl-dev=7.35.* libdb-dev=1:5.3.* \
+       libevent-dev=2.0.* libffi-dev=3.1~* libgeoip-dev=1.6.* libglib2.0-dev=2.40.* \
+       libjpeg-dev=8c-* libkrb5-dev=1.12+* liblzma-dev=5.1.* \
+       libmagickcore-dev=8:6.7.* libmagickwand-dev=8:6.7.* libmysqlclient-dev=5.5.* \
+       libncurses5-dev=5.9+* libpng12-dev=1.2.* libpq-dev=9.3.* libreadline-dev=6.3-* \
+       libsqlite3-dev=3.8.* libssl-dev=1.0.* libtool=2.4.* libwebp-dev=0.4.* \
+       libxml2-dev=2.9.* libxslt1-dev=1.1.* libyaml-dev=0.1.* make=3.81-* \
+       patch=2.7.* xz-utils=5.1.* zlib1g-dev=1:1.2.* unzip=6.0-* curl=7.35.* \
+       e2fsprogs=1.42.* iptables=1.4.* xfsprogs=3.1.* xz-utils=5.1.* \
+       mono-devel=5.* less=458-* groff=1.22.* liberror-perl=0.17-* \
+       asciidoc=8.6.* build-essential=11.* bzr=2.6.* cvs=2:1.12.* cvsps=2.1-* docbook-xml=4.5-* docbook-xsl=1.78.* dpkg-dev=1.17.* \
+       libdbd-sqlite3-perl=1.40-* libdbi-perl=1.630-* libdpkg-perl=1.17.* libhttp-date-perl=6.02-* \
+       libio-pty-perl=1:1.08-* libserf-1-1=1.3.* libsvn-perl=1.8.* libsvn1=1.8.* libtcl8.6=8.6.* libtimedate-perl=2.3000-* \
+       libunistring0=0.9.* libxml2-utils=2.9.* libyaml-perl=0.84-* python-bzrlib=2.6.* python-configobj=4.7.* \
+       sgml-base=1.26+* sgml-data=2.0.* subversion=1.8.* tcl=8.6.* tcl8.6=8.6.* xml-core=0.13+* xmlto=0.0.* xsltproc=1.1.* python3-pip \
+       tk=8.6.* gettext=0.18.* gettext-base=0.18.* libapr1=1.5.* libaprutil1=1.5.* libasprintf0c2=0.18.*  \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
+
+# Download and set up GitVersion
+RUN set -ex \
+    && wget "https://github.com/GitTools/GitVersion/releases/download/v${GITVERSION_VERSION}/GitVersion_${GITVERSION_VERSION}.zip" -O /tmp/GitVersion_${GITVERSION_VERSION}.zip \
+    && mkdir -p /usr/local/GitVersion_${GITVERSION_VERSION} \
+    && unzip /tmp/GitVersion_${GITVERSION_VERSION}.zip -d /usr/local/GitVersion_${GITVERSION_VERSION} \
+    && rm /tmp/GitVersion_${GITVERSION_VERSION}.zip \
+    && echo "mono /usr/local/GitVersion_${GITVERSION_VERSION}/GitVersion.exe \$@" >> /usr/local/bin/gitversion \
+    && chmod +x /usr/local/bin/gitversion
+
+# Install Docker
+RUN set -ex \
+    && curl -fSL "https://${DOCKER_BUCKET}/linux/static/${DOCKER_CHANNEL}/x86_64/docker-${DOCKER_VERSION}.tgz" -o docker.tgz \
+    && echo "${DOCKER_SHA256} *docker.tgz" | sha256sum -c - \
+    && tar --extract --file docker.tgz --strip-components 1  --directory /usr/local/bin/ \
+    && rm docker.tgz \
+    && docker -v \
+# set up subuid/subgid so that "--userns-remap=default" works out-of-the-box
+    && addgroup dockremap \
+    && useradd -g dockremap dockremap \
+    && echo 'dockremap:165536:65536' >> /etc/subuid \
+    && echo 'dockremap:165536:65536' >> /etc/subgid \
+    && wget "https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hack/dind" -O /usr/local/bin/dind \
+    && curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-Linux-x86_64 > /usr/local/bin/docker-compose \
+    && chmod +x /usr/local/bin/dind /usr/local/bin/docker-compose \
+# Ensure docker-compose works
+    && docker-compose version
+
+# Install dependencies by all python images equivalent to buildpack-deps:jessie
+# on the public repos.
+
+RUN set -ex \
+    && pip3 install awscli boto3
+
+VOLUME /var/lib/docker
+
+# Configure SSH
+COPY ssh_config /root/.ssh/config
+
+COPY dockerd-entrypoint.sh /usr/local/bin/
+
+ENV GOLANG_DOWNLOAD_URL="https://dl.google.com/go/go"
+    GOLANG_VERSION="1.12.2" \
+    GOLANG_DOWNLOAD_SHA256="f28c1fde8f293cc5c83ae8de76373cf76ae9306909564f54e0edcf140ce8fe3f" \
+    GOPATH="/go" \
+    DEP_VERSION="0.5.1" \
+    DEP_BINARY="dep-linux-amd64"
+
+RUN set -ex \
+    && mkdir -p "$GOPATH/src" "$GOPATH/bin" \
+    && chmod -R 777 "$GOPATH" \
+    && apt-get update && apt-get install -y --no-install-recommends \
+        pkg-config=0.26-* \
+    && apt-get clean \
+    && wget "$GOLANG_DOWNLOAD_URL$GOLANG_VERSION.linux-amd64.tar.gz" -O /tmp/golang.tar.gz \
+    && echo "$GOLANG_DOWNLOAD_SHA256 /tmp/golang.tar.gz" | sha256sum -c - \
+    && tar -xzf /tmp/golang.tar.gz -C /usr/local \
+    && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+    && wget "https://github.com/golang/dep/releases/download/v$DEP_VERSION/$DEP_BINARY" -O "$GOPATH/bin/dep" \
+    && chmod +x "$GOPATH/bin/dep"
+
+ENV PATH="$GOPATH/bin:/usr/local/go/bin:$PATH"
+WORKDIR $GOPATH

--- a/ubuntu/golang/1.12/dockerd-entrypoint.sh
+++ b/ubuntu/golang/1.12/dockerd-entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -e
+
+/usr/local/bin/dockerd \
+	--host=unix:///var/run/docker.sock \
+	--host=tcp://127.0.0.1:2375 \
+	--storage-driver=overlay2 &>/var/log/docker.log &
+
+
+tries=0
+d_timeout=60
+until docker info >/dev/null 2>&1
+do
+	if [ "$tries" -gt "$d_timeout" ]; then
+                cat /var/log/docker.log
+		echo 'Timed out trying to connect to internal docker host.' >&2
+		exit 1
+	fi
+        tries=$(( $tries + 1 ))
+	sleep 1
+done
+
+eval "$@"

--- a/ubuntu/golang/1.12/ssh_config
+++ b/ubuntu/golang/1.12/ssh_config
@@ -1,0 +1,3 @@
+Host *
+  ConnectTimeout 10
+  ConnectionAttempts 10

--- a/ubuntu/standard/1.0/Dockerfile
+++ b/ubuntu/standard/1.0/Dockerfile
@@ -17,7 +17,7 @@ ENV RUBY_MAJOR="2.6" \
  NODE_VERSION="10.15.0" \
  NODE_8_VERSION="8.11.0" \
  NVM_VERSION="0.33.5" \
- GOLANG_VERSION="1.11.4" \
+ GOLANG_VERSION="1.12.2" \
  DOTNET_SDK_VERSION="2.2.102" \
  DOCKER_VERSION="18.09.1" \
  DOCKER_COMPOSE_VERSION="1.23.2"
@@ -442,9 +442,10 @@ RUN set -ex \
 #****************     END JAVA     ****************************************************
 
 #****************     GO     **********************************************************
-ENV GOLANG_DOWNLOAD_SHA256="fb26c30e6a04ad937bbc657a1b5bba92f80096af1e8ee6da6430c045a8db3a5b" \
+ENV GOLANG_DOWNLOAD_URL="https://dl.google.com/go/go" \
+    GOLANG_DOWNLOAD_SHA256="f28c1fde8f293cc5c83ae8de76373cf76ae9306909564f54e0edcf140ce8fe3f" \
     GOPATH="/go" \
-    DEP_VERSION="0.5.0" \
+    DEP_VERSION="0.5.1" \
     DEP_BINARY="dep-linux-amd64"
 
 RUN set -ex \
@@ -453,7 +454,7 @@ RUN set -ex \
     && apt-get update && apt-get install -y --no-install-recommends \
         pkg-config \
     && apt-get clean \
-    && wget "https://storage.googleapis.com/golang/go$GOLANG_VERSION.linux-amd64.tar.gz" -O /tmp/golang.tar.gz \
+    && wget "$GOLANG_DOWNLOAD_URL$GOLANG_VERSION.linux-amd64.tar.gz" -O /tmp/golang.tar.gz \
     && echo "$GOLANG_DOWNLOAD_SHA256 /tmp/golang.tar.gz" | sha256sum -c - \
     && tar -xzf /tmp/golang.tar.gz -C /usr/local \
     && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/* \


### PR DESCRIPTION
*Issue #, if available:*

#174 

*Description of changes:*

- a new image
  - Go 1.12.2 (stable)
- change a download URL
  - changed from GCP published binary to Go official published binary.
    - org: https://storage.googleapis.com/golang/
    - new: https://dl.google.com/go/
- update Dep version
  - v0.5.0 -> v0.5.1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
