### PR TITLE
Add ChromeDriver support

### DIFF
--- a/ubuntu/standard/1.0/Dockerfile
+++ b/ubuntu/standard/1.0/Dockerfile
@@ -537,3 +537,15 @@ RUN set -ex \
     && rm -rf /tmp/google-chrome-stable_current_amd64.deb \
     && sed -i 's|HERE/chrome"|HERE/chrome" --disable-setuid-sandbox --no-sandbox|g' "/opt/google/chrome/google-chrome" \
     && google-chrome --version
+
+# Install ChromeDriver
+
+RUN CHROME_VERSION=`google-chrome --version | awk -F '[ .]' '{print $3"."$4"."$5}'` \
+      && CHROME_DRIVER_VERSION=`wget -qO- chromedriver.storage.googleapis.com/LATEST_RELEASE_$CHROME_VERSION` \
+      && wget --no-verbose -O /tmp/chromedriver_linux64.zip https://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriver_linux64.zip \
+      && rm -rf /opt/chromedriver \
+      && unzip /tmp/chromedriver_linux64.zip -d /opt \
+      && rm /tmp/chromedriver_linux64.zip \
+      && mv /opt/chromedriver /opt/chromedriver-$CHROME_DRIVER_VERSION \
+      && chmod 755 /opt/chromedriver-$CHROME_DRIVER_VERSION \
+      && ln -fs /opt/chromedriver-$CHROME_DRIVER_VERSION /usr/bin/chromedriver

--- a/ubuntu/standard/2.0/Dockerfile
+++ b/ubuntu/standard/2.0/Dockerfile
@@ -526,3 +526,15 @@ RUN set -ex \
     && rm -rf /tmp/google-chrome-stable_current_amd64.deb \
     && sed -i 's|HERE/chrome"|HERE/chrome" --disable-setuid-sandbox --no-sandbox|g' "/opt/google/chrome/google-chrome" \
     && google-chrome --version
+
+# Install ChromeDriver
+
+RUN CHROME_VERSION=`google-chrome --version | awk -F '[ .]' '{print $3"."$4"."$5}'` \
+      && CHROME_DRIVER_VERSION=`wget -qO- chromedriver.storage.googleapis.com/LATEST_RELEASE_$CHROME_VERSION` \
+      && wget --no-verbose -O /tmp/chromedriver_linux64.zip https://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriver_linux64.zip \
+      && rm -rf /opt/chromedriver \
+      && unzip /tmp/chromedriver_linux64.zip -d /opt \
+      && rm /tmp/chromedriver_linux64.zip \
+      && mv /opt/chromedriver /opt/chromedriver-$CHROME_DRIVER_VERSION \
+      && chmod 755 /opt/chromedriver-$CHROME_DRIVER_VERSION \
+      && ln -fs /opt/chromedriver-$CHROME_DRIVER_VERSION /usr/bin/chromedriver


### PR DESCRIPTION
*Description of changes:*

Added [ChromeDriver](http://chromedriver.chromium.org/).
Since [Chrome & Firefox](https://github.com/aws/aws-codebuild-docker-images/blob/f25d6b3e02a78f0a8f177f83233b2a6ac8f0dd31/ubuntu/standard/1.0/Dockerfile#L521-L539) are already installed, I think ChromeDriver would be a good addition, since I think it's not possible to use Selenium without ChromeDriver as opposed to Firefox, where it is possible.

The version is selected based on the version of Chrome, as suggested in the [documentation](http://chromedriver.chromium.org/downloads/version-selection):
> Take the Chrome version number, remove the last part, and append the result to URL "https://chromedriver.storage.googleapis.com/LATEST_RELEASE_".

I have tested this code with our CodeBuild docker images [here](https://github.com/albumprinter/aws-codebuild-docker-images/blob/java-openjdk-11-chromedriver/Dockerfile). You can see the build logs on [dockerhub](https://cloud.docker.com/u/albelli/repository/registry-1.docker.io/albelli/aws-codebuild-docker-images/builds/194c1bce-9c89-4fc1-859a-5b6578a006b2).

*Version selection explained:*
This is the output of the chrome version command
```
root@bcf4402658ea:/# google-chrome --version
Google Chrome 73.0.3683.86
```
We use `awk` to split it by ` ` and `.` and take 3,4 and 5 parts to combine them into the version that `LATEST_RELEASE_` expects.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

CC @clareliguori @subinataws @johnhanks1