### PR TITLE
Add locales package to be able to configure locales inside containers

### DIFF
--- a/ubuntu/standard/1.0/Dockerfile
+++ b/ubuntu/standard/1.0/Dockerfile
@@ -69,7 +69,7 @@ RUN set -ex \
        libio-pty-perl libserf-1-1 libsvn-perl libsvn1 libtcl8.6 libtimedate-perl \
        libxml2-utils libyaml-perl python-bzrlib python-configobj \
        sgml-base sgml-data subversion tcl tcl8.6 xml-core xmlto xsltproc \
-       tk gettext gettext-base libapr1 libaprutil1 xvfb expect \
+       tk gettext gettext-base libapr1 libaprutil1 xvfb expect locales \
     && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
     && echo "deb https://download.mono-project.com/repo/ubuntu stable-trusty main" | tee /etc/apt/sources.list.d/mono-official-stable.list \    
     && rm -rf /var/lib/apt/lists/* \

--- a/ubuntu/standard/2.0/Dockerfile
+++ b/ubuntu/standard/2.0/Dockerfile
@@ -69,7 +69,7 @@ RUN set -ex \
        libio-pty-perl libserf-1-1 libsvn-perl libsvn1 libtcl8.6 libtimedate-perl \
        libxml2-utils libyaml-perl python-bzrlib python-configobj \
        sgml-base sgml-data subversion tcl tcl8.6 xml-core xmlto xsltproc \
-       tk gettext gettext-base libapr1 libaprutil1 xvfb expect parallel \
+       tk gettext gettext-base libapr1 libaprutil1 xvfb expect parallel locales \
     && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
     && echo "deb https://download.mono-project.com/repo/ubuntu stable-bionic main" | tee /etc/apt/sources.list.d/mono-official-stable.list \    
     && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
*Description of changes:*

Add locales package to be able to follow the [documentation's recommendation](https://docs.aws.amazon.com/codebuild/latest/userguide/troubleshooting.html):
 > Issue: When you run a build that uses files with file names containing non-US English characters (for example, Chinese characters), the build fails.
> Possible cause: : Build environments provided by AWS CodeBuild have their default locale set to POSIX. POSIX localization settings are less compatible with CodeBuild and file names that contain non-US English characters and can cause related builds to fail.
> Recommended solution: Add the following commands to the pre_build section of your build specification. These commands make the build environment use US English UTF-8 for its localization settings, which is more compatible with CodeBuild and file names that contain non-US English characters.
> For build environments based on Ubuntu:

```yaml
pre_build:
  commands:
    - export LC_ALL="en_US.UTF-8"
    - locale-gen en_US en_US.UTF-8
    - dpkg-reconfigure locales
```
Currently this is what happens if the recommended command is ran:
```
[Container] 2019/04/30 11:03:07 Running command locale-gen en_US en_US.UTF-8
/codebuild/output/tmp/script.sh: 4: /codebuild/output/tmp/script.sh: locale-gen: not found
[Container] 2019/04/30 11:03:07 Command did not exit successfully locale-gen en_US en_US.UTF-8 exit status 127
[Container] 2019/04/30 11:03:07 Phase complete: PRE_BUILD State: FAILED
[Container] 2019/04/30 11:03:07 Phase context status code: COMMAND_EXECUTION_ERROR Message: Error while executing command: locale-gen en_US en_US.UTF-8. Reason: exit status 127
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
