### PR TITLE
[#202] Unable to build aws/codebuild/golang/1.11 noninteractively

### DIFF
--- a/ubuntu/golang/1.11/Dockerfile
+++ b/ubuntu/golang/1.11/Dockerfile
@@ -29,7 +29,7 @@ RUN set -ex \
     && echo "deb https://download.mono-project.com/repo/ubuntu stable-trusty main" | tee /etc/apt/sources.list.d/mono-official-stable.list \
     && apt-get update \
     && apt-get install software-properties-common -y --no-install-recommends \
-    && apt-add-repository ppa:git-core/ppa \
+    && apt-add-repository -y ppa:git-core/ppa \
     && apt-get update \
     && apt-get install git=1:2.* -y --no-install-recommends \
     && git version \


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-codebuild-docker-images/issues/202

*Description of changes:*
Adds -y flag to add-apt-repository

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
