### PR TITLE
Use port 80 (HTTP) for PHP GPG key reception

### DIFF
--- a/ubuntu/standard/2.0/Dockerfile
+++ b/ubuntu/standard/2.0/Dockerfile
@@ -217,7 +217,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
      wget -O php.tar.xz.asc "$PHP_ASC_URL"; \
      export GNUPGHOME="$(mktemp -d)"; \
      for key in $GPG_KEYS; do \
-         ( gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" \
+         ( gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" \
            || gpg --keyserver pgp.mit.edu --recv-keys "$key" \
            || gpg --keyserver keyserver.pgp.com --recv-keys "$key" ); \
      done; \


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* I was having trouble building the `ubuntu/standard/2.0` image behind a firewall. When the Python GPG key is received, it tries to use a port 80 (HTTP) server first:

https://github.com/aws/aws-codebuild-docker-images/blob/d5a24df151c2e8b967532aa1926278e635bb3a1f/ubuntu/standard/2.0/Dockerfile#L152

This modifies the PHP part to use the same server, which unblocked the build. Might be useful for some other consumers in the future? If not, feel free to close the PR.

(I've left trailing whitespace as is, since #192 addresses that, but merging that PR would much appreciated for people who's editors are set up to work with whitespace-sensitive languages :) )

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
