### PR TITLE
Unset POWERSHELL_VERSION

### DIFF
--- a/ubuntu/standard/2.0/Dockerfile
+++ b/ubuntu/standard/2.0/Dockerfile
@@ -505,6 +505,7 @@ RUN set -ex \
     && tar zxf powershell.tar.gz -C /opt/microsoft/powershell/$POWERSHELL_VERSION \
     && rm powershell.tar.gz \
     && ln -s /opt/microsoft/powershell/$POWERSHELL_VERSION/pwsh /usr/bin/pwsh
+    && unset POWERSHELL_VERSION
 #****************     END .NET-CORE     *******************************************************
 
 #****************    HEADLESS BROWSERS     *******************************************************


### PR DESCRIPTION
Description of changes:

This PR has 1 update to the powershell installation.  By removing this variable users will be able to run ansible playbooks against windows targets.  Currently this ENV var is breaking those tasks because the dockerfile is setting POWERSHELL_VERSION and this setting is being carried into ansible and erroring out due to a version mismatch when querying the windows targets.

The culprit of this conflict can be found here:

https://github.com/ansible/ansible/blob/8ef2e6da05333f49988949f973e627b582a27beb/lib/ansible/plugins/shell/powershell.py on Line 35

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.