### PR TITLE
Adding ./configure --enable-optimizations fixes docker local build failure on standard 2.0 image

### DIFF
--- a/ubuntu/standard/2.0/Dockerfile
+++ b/ubuntu/standard/2.0/Dockerfile
@@ -162,6 +162,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && ./configure \
         --enable-loadable-sqlite-extensions \
         --enable-shared \
+        --enable-optimizations \
     && make -j$(nproc) \
     && make install \
     && ldconfig \


### PR DESCRIPTION
*Issue #, if available:* No _issue_ created since it was just a one liner

*Description of changes:*
Basically if you follow these steps to build the "`standard:2.0`" image locally,
```
$ git clone https://github.com/aws/aws-codebuild-docker-images.git
$ cd aws-codebuild-docker-images
$ cd ubuntu/standard/2.0
$ docker build -t aws/codebuild/standard:2.0 .

```
the build fails with this message:
`If you want a release build with all stable optimizations active (PGO, etc), please run ./configure --enable-optimizations`

Adding that flag (`--enable-optimizations`) to the Dockerfile in `./ubuntu/standard/2.0/Dockerfile` resolved the issue

Please notice, adding that flag increases the build time during the optimization phase; it took me about `1h13mins` for the build `(docker build -t aws/codebuild/joel-custom-standard:2.0 .)` to complete

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
