### PR TITLE
bugfix:  another instance where we need to install wheel

### DIFF
--- a/ubuntu/standard/2.0/Dockerfile
+++ b/ubuntu/standard/2.0/Dockerfile
@@ -108,6 +108,7 @@ RUN curl -sS -o /usr/local/bin/aws-iam-authenticator https://amazon-eks.s3-us-we
     && chmod +x /usr/local/bin/kubectl /usr/local/bin/aws-iam-authenticator /usr/local/bin/ecs-cli
 
 RUN set -ex \
+    && pip3 install --upgrade setuptools wheel
     && pip3 install awscli boto3  
 
 VOLUME /var/lib/docker


### PR DESCRIPTION
awscli depends on pyyaml which has a `bdist_wheel` install.  In order to
use `bdist_wheel` the `wheel` package has to be installed.  Sorry for
missing this earlier @Sabin Mathews!

*Issue #, if available:*

*Description of changes:*

When running docker build, there will be a failure of the installation of pyyaml because pip installation of pyyaml requires `bdist_wheel`.  `bdist_wheel` was removed from setuptools and moved to a separate pip package `wheel`.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
