### PR TITLE
Fix linebreak syntax error in Dockerfile

### DIFF
--- a/ubuntu/standard/2.0/Dockerfile
+++ b/ubuntu/standard/2.0/Dockerfile
@@ -108,7 +108,7 @@ RUN curl -sS -o /usr/local/bin/aws-iam-authenticator https://amazon-eks.s3-us-we
     && chmod +x /usr/local/bin/kubectl /usr/local/bin/aws-iam-authenticator /usr/local/bin/ecs-cli
 
 RUN set -ex \
-    && pip3 install --upgrade setuptools wheel
+    && pip3 install --upgrade setuptools wheel \
     && pip3 install awscli boto3  
 
 VOLUME /var/lib/docker


### PR DESCRIPTION
This PR adds a linebreak character that is missing on this line, preventing the Dockerfile from being run due to a parsing error:

```
Error response from daemon: Dockerfile parse error line 112: unknown instruction: &&
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
