### PR TITLE
Add nodejs 12.13.1 LTS

### DIFF
--- a/ubuntu/standard/2.0/runtimes.yml
+++ b/ubuntu/standard/2.0/runtimes.yml
@@ -82,6 +82,10 @@ runtimes:
           - rbenv global 2.6.4
   nodejs:
     versions:
+      12:
+        commands:
+          - echo "Installing Node.js version 12 ..."
+          - n 12.13.1
       10:
         commands:
           - echo "Installing Node.js version 10 ..."


### PR DESCRIPTION
nodejs 12 was promoted to LTS on oct 22

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
