### PR TITLE
Lambdas run on Ruby 2.5, so having the standard images able to just switch to that to build lambda packages should be required

### DIFF
--- a/al2/aarch64/standard/1.0/Dockerfile
+++ b/al2/aarch64/standard/1.0/Dockerfile
@@ -1,10 +1,11 @@
 FROM amazonlinux:2
 
 ENV RUBY_VERSION="2.6.5" \
+ RUBY_25_VERSION="2.5.6" \
  PYTHON_37_VERSION="3.7.4" \
  PYTHON_VERSION="3.8.0" \
  PHP_VERSION=7.3.10 \
- JAVA_VERSION=11 \ 
+ JAVA_VERSION=11 \
  NODE_VERSION="12.13.0" \
  NODE_10_VERSION="10.16.3" \
  NODE_8_VERSION="8.16.0" \
@@ -16,8 +17,8 @@ ENV RUBY_VERSION="2.6.5" \
 
 ARG CHINA_REGION
 
-#****************        Utilities     ********************************************* 
-ENV DOCKER_BUCKET="download.docker.com" \    
+#****************        Utilities     *********************************************
+ENV DOCKER_BUCKET="download.docker.com" \
     DOCKER_CHANNEL="stable" \
     DOCKER_18_SHA256="c4857639514471e2d1aa6d567880b7fc226437ede462021ed44157d4dcd11dc8" \
     DOCKER_SHA256="44158b9fe44e8b5d3c1226a5d880425850d6f8ec383e4cf053f401e1a8fc269d" \
@@ -90,8 +91,8 @@ RUN set -ex \
     && useradd -g dockremap dockremap \
     && echo 'dockremap:165536:65536' >> /etc/subuid \
     && echo 'dockremap:165536:65536' >> /etc/subgid \
-    && wget "https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hack/dind" -O /usr/local/bin/dind 
-# TODO there is no existing docker compose executable for ARM. 
+    && wget "https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hack/dind" -O /usr/local/bin/dind
+# TODO there is no existing docker compose executable for ARM.
 #   && curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-Linux-x86_64 > /usr/local/bin/docker-compose \
 #   && chmod +x /usr/local/bin/dind /usr/local/bin/docker-compose
 #   && docker-compose version
@@ -123,6 +124,7 @@ RUN set -ex \
     && mkdir -p $RBENV_SRC_DIR/plugins \
     && git clone https://github.com/rbenv/ruby-build.git $RUBY_BUILD_SRC_DIR \
     && sh $RUBY_BUILD_SRC_DIR/install.sh \
+    && rbenv install $RUBY_25_VERSION \
     && rbenv install $RUBY_VERSION && rbenv global $RUBY_VERSION \
     && ruby -v
 

--- a/al2/aarch64/standard/1.0/runtimes.yml
+++ b/al2/aarch64/standard/1.0/runtimes.yml
@@ -14,13 +14,13 @@ runtimes:
           - export JDK_HOME="$JDK_11_HOME"
 
           - |-
-            for tool_path in "$JAVA_HOME"/bin/*; 
+            for tool_path in "$JAVA_HOME"/bin/*;
              do tool=`basename "$tool_path"`;
-              if [ $tool != 'java-rmi.cgi' ]; 
-              then 
+              if [ $tool != 'java-rmi.cgi' ];
+              then
                rm -f /usr/bin/$tool /var/lib/alternatives/$tool \
                 && update-alternatives --install /usr/bin/$tool $tool $tool_path 20000;
-              fi; 
+              fi;
             done
       corretto8:
         commands:
@@ -71,6 +71,10 @@ runtimes:
           - echo "Installing PHP version 7.3 ..."
   ruby:
     versions:
+      2.5:
+        commands:
+          - echo "Installing Ruby version 2.5 ..."
+          - rbenv global 2.5.6
       2.6:
         commands:
           - echo "Installing Ruby version 2.6 ..."

--- a/al2/x86_64/standard/1.0/Dockerfile
+++ b/al2/x86_64/standard/1.0/Dockerfile
@@ -12,6 +12,7 @@
 FROM amazonlinux:2
 
 ENV RUBY_VERSION="2.6.4" \
+ RUBY_25_VERSION="2.5.6" \
  PYTHON_VERSION="3.7.4" \
  PHP_VERSION=7.3.9 \
  JAVA_VERSION=11 \
@@ -112,6 +113,7 @@ RUN set -ex \
     && mkdir -p $RBENV_SRC_DIR/plugins \
     && git clone https://github.com/rbenv/ruby-build.git $RUBY_BUILD_SRC_DIR \
     && sh $RUBY_BUILD_SRC_DIR/install.sh \
+    && rbenv install $RUBY_25_VERSION \
     && rbenv install $RUBY_VERSION && rbenv global $RUBY_VERSION \
     && ruby -v
 
@@ -523,4 +525,3 @@ RUN set -ex \
     && yum clean all
 
 ENTRYPOINT ["dockerd-entrypoint.sh"]
-

--- a/al2/x86_64/standard/1.0/runtimes.yml
+++ b/al2/x86_64/standard/1.0/runtimes.yml
@@ -75,6 +75,10 @@ runtimes:
           - echo "Installing PHP version 7.3 ..."
   ruby:
     versions:
+      2.5:
+        commands:
+          - echo "Installing Ruby version 2.5 ..."
+          - rbenv global 2.5.6
       2.6:
         commands:
           - echo "Installing Ruby version 2.6 ..."
@@ -99,5 +103,3 @@ runtimes:
       2.2:
         commands:
           - echo "Installing .NET version 2.2 ..."
-
-

--- a/al2/x86_64/standard/2.0/Dockerfile
+++ b/al2/x86_64/standard/2.0/Dockerfile
@@ -1,6 +1,7 @@
 FROM amazonlinux:2
 
 ENV RUBY_VERSION="2.6.4" \
+ RUBY_25_VERSION="2.5.6" \
  PYTHON_VERSION="3.8.0" \
  PHP_VERSION=7.3.9 \
  JAVA_VERSION=11 \
@@ -101,6 +102,7 @@ RUN set -ex \
     && mkdir -p $RBENV_SRC_DIR/plugins \
     && git clone https://github.com/rbenv/ruby-build.git $RUBY_BUILD_SRC_DIR \
     && sh $RUBY_BUILD_SRC_DIR/install.sh \
+    && rbenv install $RUBY_25_VERSION \
     && rbenv install $RUBY_VERSION && rbenv global $RUBY_VERSION \
     && ruby -v
 

--- a/ubuntu/standard/2.0/Dockerfile
+++ b/ubuntu/standard/2.0/Dockerfile
@@ -12,6 +12,7 @@
 FROM ubuntu:18.04
 
 ENV RUBY_VERSION="2.6.4" \
+ RUBY_25_VERSION="2.5.6" \
  PYTHON_VERSION="3.7.4" \
  PHP_VERSION=7.3.9 \
  JAVA_VERSION=11 \
@@ -136,7 +137,9 @@ RUN set -ex \
     && mkdir -p $RBENV_SRC_DIR/plugins \
     && git clone https://github.com/rbenv/ruby-build.git $RUBY_BUILD_SRC_DIR \
     && sh $RUBY_BUILD_SRC_DIR/install.sh \
-    && rbenv install $RUBY_VERSION && rbenv global $RUBY_VERSION
+    && rbenv install $RUBY_25_VERSION \
+    && rbenv install $RUBY_VERSION && rbenv global $RUBY_VERSION \
+    && ruby -v
 
 #**************** END RUBY *****************************************************
 
@@ -575,5 +578,3 @@ RUN set -ex \
     && chromedriver --version
 
 ENTRYPOINT ["dockerd-entrypoint.sh"]
-
-

--- a/ubuntu/standard/2.0/runtimes.yml
+++ b/ubuntu/standard/2.0/runtimes.yml
@@ -76,6 +76,10 @@ runtimes:
           - echo "Installing PHP version 7.3 ..."
   ruby:
     versions:
+      2.5:
+        commands:
+          - echo "Installing Ruby version 2.5 ..."
+          - rbenv global 2.5.6
       2.6:
         commands:
           - echo "Installing Ruby version 2.6 ..."
@@ -100,5 +104,3 @@ runtimes:
       2.2:
         commands:
           - echo "Installing .NET version 2.2 ..."
-
-

--- a/ubuntu/standard/3.0/Dockerfile
+++ b/ubuntu/standard/3.0/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:18.04
 
 ENV RUBY_VERSION="2.6.4" \
+ RUBY_25_VERSION="2.5.6" \
  PYTHON_VERSION="3.8.0" \
  PHP_VERSION=7.3.9 \
  JAVA_VERSION=11 \
@@ -125,7 +126,9 @@ RUN set -ex \
     && mkdir -p $RBENV_SRC_DIR/plugins \
     && git clone https://github.com/rbenv/ruby-build.git $RUBY_BUILD_SRC_DIR \
     && sh $RUBY_BUILD_SRC_DIR/install.sh \
-    && rbenv install $RUBY_VERSION && rbenv global $RUBY_VERSION
+    && rbenv install $RUBY_25_VERSION \
+    && rbenv install $RUBY_VERSION && rbenv global $RUBY_VERSION \
+    && ruby -v
 
 #**************** END RUBY *****************************************************
 


### PR DESCRIPTION

*Issue #, if available:*
#281 

*Description of changes:*
Include Ruby 2.5 runtime since Lambda uses that version to run. Since Lambda uses that version, I would think it should be required in the provided images so that support of the AWS service is fulfilled.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
