### PR TITLE
add alias to "python: 3" for AL2 images

### DIFF
--- a/al2/x86_64/standard/1.0/runtimes.yml
+++ b/al2/x86_64/standard/1.0/runtimes.yml
@@ -68,6 +68,9 @@ runtimes:
       3.7:
         commands:
           - echo "Installing Python version 3.7 ..."
+      3:
+        commands:
+          - echo "Installing Python version 3.7 ..."
   php:
     versions:
       7.3:
@@ -99,5 +102,3 @@ runtimes:
       2.2:
         commands:
           - echo "Installing .NET version 2.2 ..."
-
-

--- a/al2/x86_64/standard/2.0/runtimes.yml
+++ b/al2/x86_64/standard/2.0/runtimes.yml
@@ -68,6 +68,9 @@ runtimes:
       3.8:
         commands:
           - echo "Installing Python version 3.8 ..."
+      3:
+        commands:
+          - echo "Installing Python version 3.8 ..."
   php:
     versions:
       7.3:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change adds an alias to the major version of python 3.  I have a situation where there are a good number of pipelines using the same `buildspec.yml` file as part of a common "template" repo which gets merged with a "variables" repo per pipeline.  I would like to manage backwards compatibility myself and allow the individual deploy projects to move forward at their own pace from CodeBuild AL2 Standard image 1.0 to 2.0.  Given the relatively quickly cycle time between 1.0 and 2.0, I feel like this is something I need to give more attention to.

Workarounds
- use a runtime that is not needed but will be supported for a while like `corretto8` (hacky)
- generate each pipeline with a static, frozen in time `buildspec.yml` (could work, but loses some flexibility of refactoring what script structure I delegate down to for the actual work)
- use my own container image (but you all do a good job at making sure the standard image is secure, etc)

I understand my setup is kind of an edge case and am fine if you all want to close this issue.  I could see just python "3" being too easy to choose instead of 3.7/8 and then biting someone.  I would also be great with not needing to specify `runtime-versions` in the buildspec, but I assume that choice was made for similar reasons?

My current buildspec for reference:
```
version: 0.2

phases:
  install:
    runtime-versions:
      docker: 18
    commands:
      - ./resolve-template-version.sh # prevent any directory traversal injection attempts
      - cd ./$(cat ./template_version) # change into template version specific subdirectory
      # later will have resolve-variables.py and source resolved-variables.env here
      - ./install.sh

  pre_build:
    commands:
      - ./pre_build.sh

  build:
    commands:
      - ./build.sh
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
