### PR TITLE
directly assigned buildspec path to docker command outside of path ch…

### DIFF
--- a/local_builds/codebuild_build.sh
+++ b/local_builds/codebuild_build.sh
@@ -41,7 +41,7 @@ function usage {
     echo "               * For sourceIdentifier, use a value that is fewer than 128 characters and contains only alphanumeric characters and underscores"
     echo "  -c        Use the AWS configuration and credentials from your local host. This includes ~/.aws and any AWS_* environment variables."
     echo "  -p        Used to specify the AWS CLI Profile."
-    echo "  -b FILE   Used to specify a buildspec override file. Defaults to buildspec.yml in the source directory."
+    echo "  -b FILE   Used to specify a buildspec override file. Defaults to buildspec.yml in the source directory. Takes a relative path to the primary source directory"
     echo "  -m        Used to mount the source directory to the customer build container directly."
     echo "  -e FILE   Used to specify a file containing environment variables."
     echo "            (-e) File format expectations:"
@@ -121,7 +121,7 @@ fi
 
 if [ -n "$buildspec" ]
 then
-    docker_command+=" -e \"BUILDSPEC=$(allOSRealPath $buildspec)\""
+    docker_command+=" -e \"BUILDSPEC=$buildspec\""
 fi
 
 if [ -n "$environment_variable_file" ]


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-codebuild-docker-images/issues/105 https://github.com/aws/aws-codebuild-docker-images/issues/276

*Description of changes:*
Removed call to `allOSRealPath()` when assigning the buildspec path to the docker command. `amazon/aws-codebuild-local:latest` evidently takes this path as relative to the mounted -v. The function returns an expanded full path which can't be traversed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
