### PR TITLE
Update ubuntu/standard/3.0 to use stunnel 5.56

### DIFF
--- a/ubuntu/standard/3.0/Dockerfile
+++ b/ubuntu/standard/3.0/Dockerfile
@@ -565,16 +565,16 @@ RUN set -ex \
 
 RUN set -ex \
    && apt-get install -y openssl \
-   && curl -o stunnel-5.55.tar.gz https://www.stunnel.org/downloads/stunnel-5.55.tar.gz \
-   && tar xvfz stunnel-5.55.tar.gz \
-   && cd stunnel-5.55 \
+   && curl -o stunnel-5.56.tar.gz https://www.stunnel.org/downloads/stunnel-5.56.tar.gz \
+   && tar xvfz stunnel-5.56.tar.gz \
+   && cd stunnel-5.56 \
    && ./configure \
    && make \
    && make install \
    && openssl genrsa -out key.pem 2048 \
    && openssl req -new -x509 -key key.pem -out cert.pem -days 1095 -subj "/C=US/ST=Washington/L=Seattle/O=Amazon/OU=Codebuild/CN=codebuild.amazon.com" \
    && cat key.pem cert.pem >> /usr/local/etc/stunnel/stunnel.pem \
-   && cd .. ; rm -rf stunnel-5.55* \
+   && cd .. ; rm -rf stunnel-5.56* \
    && apt-get clean
 
 ENTRYPOINT ["dockerd-entrypoint.sh"]


### PR DESCRIPTION
*Issue #, if available:*
 N/A

*Description of changes:*
* stunnel upstream removed the originally used 5.55 from their
  official downloads section, breaking the docker build.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
