### PR TITLE
Add iproute2 to be able to fetch ip address (3.0)

### DIFF
--- a/ubuntu/standard/3.0/Dockerfile
+++ b/ubuntu/standard/3.0/Dockerfile
@@ -64,7 +64,7 @@ RUN set -ex \
        libxml2-utils libyaml-perl python-bzrlib python-configobj \
        sgml-base sgml-data subversion tcl tcl8.6 xml-core xmlto xsltproc \
        tk gettext gettext-base libapr1 libaprutil1 xvfb expect parallel \
-       locales rsync \
+       locales rsync iproute2 \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 


### PR DESCRIPTION
We are running our tests as follows:

```
docker-compose up -d
docker build -t $REPO:$VERSION .
docker run --add-host=host.docker.internal:$(ip route | grep docker0 | awk '{print $9}') $REPO:$VERSION npm run ci
```

Currently there is no way for us to get the ip address of the docker host. Currently we are installing `iproute2` as neither `ip` nor `ifconfig` are available in the docker image.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
