### PR TITLE
Add iproute2 to be able to fetch ip address (4.0)

### DIFF
--- a/al2/x86_64/standard/3.0/Dockerfile
+++ b/al2/x86_64/standard/3.0/Dockerfile
@@ -18,7 +18,7 @@ RUN set -ex \
     && yum install -y \
            GeoIP-devel ImageMagick asciidoc bzip2-devel bzr bzrtools cvs cvsps \
            docbook-dtds docbook-style-xsl dpkg-dev e2fsprogs expat-devel expect fakeroot \
-           glib2-devel groff gzip icu iptables jq krb5-server libargon2-devel \
+           glib2-devel groff gzip icu iproute iptables jq krb5-server libargon2-devel \
            libcurl-devel libdb-devel libedit-devel libevent-devel libffi-devel \
            libicu-devel libjpeg-devel libpng-devel libserf libsqlite3x-devel \
            libtidy-devel libunwind libwebp-devel libxml2-devel libxslt libxslt-devel \

--- a/ubuntu/standard/4.0/Dockerfile
+++ b/ubuntu/standard/4.0/Dockerfile
@@ -24,8 +24,8 @@ RUN set -ex \
           apt-utils asciidoc autoconf automake build-essential bzip2 \
           bzr curl cvs cvsps dirmngr docbook-xml docbook-xsl dpkg-dev \
           e2fsprogs expect fakeroot file g++ gcc gettext gettext-base \
-          git groff gzip imagemagick iptables jq less libapr1 libaprutil1 \
-          libargon2-0-dev libbz2-dev libc6-dev libcurl4-openssl-dev \
+          git groff gzip imagemagick iproute2 iptables jq less libapr1 \
+          libaprutil1 libargon2-0-dev libbz2-dev libc6-dev libcurl4-openssl-dev \
           libdb-dev libdbd-sqlite3-perl libdbi-perl libdpkg-perl \
           libedit-dev liberror-perl libevent-dev libffi-dev libgeoip-dev \
           libglib2.0-dev libhttp-date-perl libio-pty-perl libjpeg-dev \


### PR DESCRIPTION
We are running our tests as follows:

```
docker-compose up -d
docker build -t $REPO:$VERSION .
docker run --add-host=host.docker.internal:$(ip route | grep docker0 | awk '{print $9}') $REPO:$VERSION npm run ci
```

Currently there is no way for us to get the ip address of the docker host. Currently we are installing `iproute2` as neither `ip` nor `ifconfig` are available in the docker image.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
