### PR TITLE
Fixes docker version number typo

### DIFF
--- a/ubuntu/standard/4.0/runtimes.yml
+++ b/ubuntu/standard/4.0/runtimes.yml
@@ -112,7 +112,7 @@ runtimes:
     versions:
       18:
         commands:
-          - echo "Using Docker 19"
+          - echo "Using Docker 18"
       19:
         commands:
           - echo "Using Docker 19"


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Using docker 18 in the standard:4.0 image runtime hopefully no longer lies to people about being version 19.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
