### PR TITLE
[ISSUE-324]  Added option to install shared objects for python

### DIFF
--- a/ubuntu/standard/4.0/Dockerfile
+++ b/ubuntu/standard/4.0/Dockerfile
@@ -239,7 +239,7 @@ ENV PYTHON_38_VERSION="3.8.1" \
 ENV PYTHON_PIP_VERSION=19.3.1
 
 COPY tools/runtime_configs/python/$PYTHON_37_VERSION /root/.pyenv/plugins/python-build/share/python-build/$PYTHON_37_VERSION
-RUN   CONFIGURE_OPTS=--enable-shared pyenv install $PYTHON_37_VERSION; rm -rf /tmp/*
+RUN   pyenv install $PYTHON_37_VERSION; rm -rf /tmp/*
 RUN   pyenv global  $PYTHON_37_VERSION
 RUN set -ex \
     && pip3 install --no-cache-dir --upgrade --force-reinstall "pip==$PYTHON_PIP_VERSION" \
@@ -248,7 +248,7 @@ RUN set -ex \
 
 
 COPY tools/runtime_configs/python/$PYTHON_38_VERSION /root/.pyenv/plugins/python-build/share/python-build/$PYTHON_38_VERSION
-RUN   CONFIGURE_OPTS=--enable-shared pyenv install $PYTHON_38_VERSION; rm -rf /tmp/*
+RUN   pyenv install $PYTHON_38_VERSION; rm -rf /tmp/*
 RUN   pyenv global  $PYTHON_38_VERSION
 RUN set -ex \
     && pip3 install --no-cache-dir --upgrade --force-reinstall "pip==$PYTHON_PIP_VERSION" \

--- a/ubuntu/standard/4.0/Dockerfile
+++ b/ubuntu/standard/4.0/Dockerfile
@@ -239,7 +239,7 @@ ENV PYTHON_38_VERSION="3.8.1" \
 ENV PYTHON_PIP_VERSION=19.3.1
 
 COPY tools/runtime_configs/python/$PYTHON_37_VERSION /root/.pyenv/plugins/python-build/share/python-build/$PYTHON_37_VERSION
-RUN   pyenv install $PYTHON_37_VERSION; rm -rf /tmp/*
+RUN   CONFIGURE_OPTS=--enable-shared pyenv install $PYTHON_37_VERSION; rm -rf /tmp/*
 RUN   pyenv global  $PYTHON_37_VERSION
 RUN set -ex \
     && pip3 install --no-cache-dir --upgrade --force-reinstall "pip==$PYTHON_PIP_VERSION" \
@@ -248,7 +248,7 @@ RUN set -ex \
 
 
 COPY tools/runtime_configs/python/$PYTHON_38_VERSION /root/.pyenv/plugins/python-build/share/python-build/$PYTHON_38_VERSION
-RUN   pyenv install $PYTHON_38_VERSION; rm -rf /tmp/*
+RUN   CONFIGURE_OPTS=--enable-shared pyenv install $PYTHON_38_VERSION; rm -rf /tmp/*
 RUN   pyenv global  $PYTHON_38_VERSION
 RUN set -ex \
     && pip3 install --no-cache-dir --upgrade --force-reinstall "pip==$PYTHON_PIP_VERSION" \

--- a/ubuntu/standard/4.0/tools/runtime_configs/python/3.7.6
+++ b/ubuntu/standard/4.0/tools/runtime_configs/python/3.7.6
@@ -1,4 +1,4 @@
-export PYTHON_CONFIGURE_OPTS="\
+export PYTHON_CONFIGURE_OPTS="--enable-shared \
             --enable-loadable-sqlite-extensions"  
 
 # Don't change below this line.

--- a/ubuntu/standard/4.0/tools/runtime_configs/python/3.8.1
+++ b/ubuntu/standard/4.0/tools/runtime_configs/python/3.8.1
@@ -1,4 +1,4 @@
-export PYTHON_CONFIGURE_OPTS="\
+export PYTHON_CONFIGURE_OPTS="--enable-shared \
             --enable-loadable-sqlite-extensions"
 
 # Don't change below this line.


### PR DESCRIPTION
## Problem?

Many commonly used python libraries, like mysqlclient, require the
python shared object files to be installed and available.  pyenv does
not install these shared objects by default.

## Solution!

Enable installation of the shared objects needed using
`CONFIGURE_OPTS=--enable-shared`.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
