### PR TITLE
Fix geckodriver download

### DIFF
--- a/ubuntu/standard/2.0/Dockerfile
+++ b/ubuntu/standard/2.0/Dockerfile
@@ -545,7 +545,7 @@ RUN set -ex \
 # Install GeckoDriver
 
 RUN set -ex \
-    && curl -s https://api.github.com/repos/mozilla/geckodriver/releases/latest | grep browser_download_url | grep linux64.tar.gz | cut -d : -f 2,3 | tr -d ' "' | wget -O /tmp/geckodriver-latest-linux64.tar.gz -qi - \
+    && curl -s https://api.github.com/repos/mozilla/geckodriver/releases/latest | jq -r '.assets[] | select(.browser_download_url | contains("linux64")).browser_download_url' | wget -O /tmp/geckodriver-latest-linux64.tar.gz -qi - \
     && tar -xzf /tmp/geckodriver-latest-linux64.tar.gz -C /opt \
     && rm /tmp/geckodriver-latest-linux64.tar.gz \
     && chmod 755 /opt/geckodriver \


### PR DESCRIPTION
*Issue #340*

*Description of changes:*

This PR updates the `RUN` command in the `Dockerfile` to use `jq` to isolate the latest 64bit Linux release of `geckodriver`. This is reliable in cases where the formatting of the JSON response from the GitHub API changes and avoids the use of `grep` / `cut` / `tr`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
