### PR TITLE
feat: able to use buildx

### DIFF
--- a/ubuntu/standard/4.0/Dockerfile
+++ b/ubuntu/standard/4.0/Dockerfile
@@ -449,7 +449,12 @@ RUN set -ex \
     && curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-Linux-x86_64 > /usr/local/bin/docker-compose \
     && chmod +x /usr/local/bin/dind /usr/local/bin/docker-compose \
     # Ensure docker-compose works
-    && docker-compose version
+    && docker-compose version \
+    && DOCKER_BUILDKIT=1 docker build --platform=local -o . git://github.com/docker/buildx \
+    && mkdir -p ~/.docker/cli-plugins \
+    && mv buildx ~/.docker/cli-plugins/docker-buildx \
+    # Ensure buildx works
+    && docker buildx version
 
 VOLUME /var/lib/docker
 #*********************** END  DOCKER  ****************************


### PR DESCRIPTION
*problem*

We can not use Buildx on CodeBuild.

```
$ docker buildx version
docker: 'buildx' is not a docker command.
```

To use Buildx, 

I must write this script on `buildspec.yml`.

```
$ DOCKER_BUILDKIT=1 docker build --platform=local -o . git://github.com/docker/buildx 
$ mkdir -p ~/.docker/cli-plugins
$ mv buildx ~/.docker/cli-plugins/docker-buildx
```

This leads to longer build hours.

*Description of changes:*

Building Buildx on CodeBuild base docker images.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
