### PR TITLE
Fix typo in echo command for Docker 18

### DIFF
--- a/ubuntu/standard/4.0/runtimes.yml
+++ b/ubuntu/standard/4.0/runtimes.yml
@@ -112,7 +112,7 @@ runtimes:
     versions:
       18:
         commands:
-          - echo "Using Docker 19"
+          - echo "Using Docker 18"
       19:
         commands:
           - echo "Using Docker 19"


### PR DESCRIPTION
*Issue #, if available:*

No issue, just a typo noticed while browsing the repo.

*Description of changes:*

An output message is wrong which is unlikely to be seen, but an easy fix.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
