### PR TITLE
fix: bump node to latest 10.x 10.23.0

### DIFF
--- a/ubuntu/standard/4.0/Dockerfile
+++ b/ubuntu/standard/4.0/Dockerfile
@@ -218,7 +218,7 @@ RUN set -ex \
 #****************      NODEJS     ****************************************************
 
 ENV NODE_12_VERSION="12.18.0" \
-    NODE_10_VERSION="10.21.0"
+    NODE_10_VERSION="10.23.0"
 
 RUN     n $NODE_10_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \
      && n $NODE_12_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-codebuild-docker-images/issues/399

*Description of changes:*
Bump node to latest version 10.23.0 from https://nodejs.org/dist/latest-v10.x/

This is currently blocking: aws/aws-sdk-js-v3#1673

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
