### PR TITLE
Add amazon ecr credential helper

### DIFF
--- a/al2/x86_64/standard/3.0/Dockerfile
+++ b/al2/x86_64/standard/3.0/Dockerfile
@@ -449,6 +449,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin -
 # Install and configure amazon-ecr-credential-helper
 RUN PYTHON=python2 /usr/bin/amazon-linux-extras enable docker
 RUN yum install -y amazon-ecr-credential-helper
+RUN mkdir -p /root/.docker && echo '{"credsStore": "ecr-login"}' > /root/.docker/config.json
 
 #===================END of runtimes_3 ==============
 FROM runtimes_3 AS al2_v3

--- a/al2/x86_64/standard/3.0/Dockerfile
+++ b/al2/x86_64/standard/3.0/Dockerfile
@@ -446,6 +446,10 @@ RUN echo "memory_limit = 1G;" >> "/root/.phpenv/versions/$PHP_74_VERSION/etc/con
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
 #****************      END PHP     ****************************************************
 
+# Install and configure amazon-ecr-credential-helper
+RUN PYTHON=python2 /usr/bin/amazon-linux-extras enable docker
+RUN yum install -y amazon-ecr-credential-helper
+
 #===================END of runtimes_3 ==============
 FROM runtimes_3 AS al2_v3
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added installation of the `amazon-ecr-credential-helper`.
https://github.com/awslabs/amazon-ecr-credential-helper

This tool is useful when building code that uses docker images from different ECR repositories in several different AWS accounts, since we can omit the `aws ecr get-login` with many `--registry-ids` parameters.

By installing this tool in the CodeBuild image instead of on-demand, we can keep our `buildspec.yml` files cleaner.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
