### PR TITLE
Use nodenv rather than n for Node.js version management

### DIFF
--- a/al2/aarch64/standard/1.0/Dockerfile
+++ b/al2/aarch64/standard/1.0/Dockerfile
@@ -411,19 +411,25 @@ RUN cd /usr/local/python38/bin \
 
 #****************      NODEJS     ****************************************************
 
- ENV N_SRC_DIR="$SRC_DIR/n"
+ ENV NODENV_SRC_DIR="/usr/local/nodenv"
 
- RUN git clone https://github.com/tj/n $N_SRC_DIR \
-     && cd $N_SRC_DIR && make install \
-     && n $NODE_8_VERSION && npm install --save-dev -g grunt && npm install --save-dev -g grunt-cli && npm install --save-dev -g webpack \
-     && n $NODE_10_VERSION && npm install --save-dev -g grunt && npm install --save-dev -g grunt-cli && npm install --save-dev -g webpack \
-     && n $NODE_VERSION && npm install --save-dev -g grunt && npm install --save-dev -g grunt-cli && npm install --save-dev -g webpack \
+ ENV PATH="/root/.nodenv/shims:$NODENV_SRC_DIR/bin:$NODENV_SRC_DIR/shims:$PATH" \
+     NODE_BUILD_SRC_DIR="$NODENV_SRC_DIR/plugins/node-build"
+
+ RUN set -ex \
+     && git clone https://github.com/nodenv/nodenv.git $NODENV_SRC_DIR \
+     && mkdir -p $NODENV_SRC_DIR/plugins \
+     && git clone https://github.com/nodenv/node-build.git $NODE_BUILD_SRC_DIR \
+     && sh $NODE_BUILD_SRC_DIR/install.sh \
+     && nodenv install $NODE_8_VERSION && env NODENV_VERSION=$NODE_8_VERSION npm install --save-dev -g grunt grunt-cli webpack \
+     && nodenv install $NODE_10_VERSION && env NODENV_VERSION=$NODE_10_VERSION npm install --save-dev -g grunt grunt-cli webpack \
+     && nodenv install $NODE_VERSION && env NODENV_VERSION=$NODE_VERSION npm install --save-dev -g grunt grunt-cli webpack \
      && curl -sSL https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo \
      && rpm --import https://dl.yarnpkg.com/rpm/pubkey.gpg \
      && yum install -y yarn \
      && yarn --version \
-     && cd / && rm -rf $N_SRC_DIR \
-     && yum clean all
+     && yum clean all \
+     && nodenv global $NODE_VERSION
 
 #****************      END NODEJS     ****************************************************
 

--- a/al2/aarch64/standard/1.0/runtimes.yml
+++ b/al2/aarch64/standard/1.0/runtimes.yml
@@ -80,15 +80,15 @@ runtimes:
       12:
         commands:
           - echo "Installing Node.js version 12 ..."
-          - n 12.13.0
+          - nodenv global 12.13.0
       10:
         commands:
           - echo "Installing Node.js version 10 ..."
-          - n 10.16.3
+          - nodenv global 10.16.3
       8:
         commands:
           - echo "Installing Node.js version 8 ..."
-          - n 8.16.0
+          - nodenv global 8.16.0
   docker:
     versions:
       18:

--- a/al2/aarch64/standard/2.0/Dockerfile
+++ b/al2/aarch64/standard/2.0/Dockerfile
@@ -93,9 +93,16 @@ RUN set -ex  \
 && chmod +x /usr/local/bin/dotnet-install.sh
 
 ##nodejs
-ENV N_SRC_DIR="$SRC_DIR/n"
-RUN git clone https://github.com/tj/n $N_SRC_DIR \
-     && cd $N_SRC_DIR && make install
+ENV NODENV_SRC_DIR="/usr/local/nodenv"
+
+ENV PATH="/root/.nodenv/shims:$NODENV_SRC_DIR/bin:$NODENV_SRC_DIR/shims:$PATH" \
+    NODE_BUILD_SRC_DIR="$NODENV_SRC_DIR/plugins/node-build"
+
+RUN set -ex \
+    && git clone https://github.com/nodenv/nodenv.git $NODENV_SRC_DIR \
+    && mkdir -p $NODENV_SRC_DIR/plugins \
+    && git clone https://github.com/nodenv/node-build.git $NODE_BUILD_SRC_DIR \
+    && sh $NODE_BUILD_SRC_DIR/install.sh
 
 ##ruby
 ENV RBENV_SRC_DIR="/usr/local/rbenv"
@@ -224,12 +231,12 @@ RUN set -ex \
 
 ENV NODE_10_VERSION="10.21.0"
 
-RUN  n $NODE_10_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \
+RUN  nodenv install $NODE_10_VERSION && env NODENV_VERSION=$NODE_10_VERSION npm install --save-dev -g -f grunt grunt-cli webpack \
      && curl -sSL https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo \
      && rpm --import https://dl.yarnpkg.com/rpm/pubkey.gpg \
      && yum install -y yarn \
      && yarn --version \
-     && cd / && rm -rf $N_SRC_DIR; rm -rf /tmp/*
+     && rm -rf /tmp/*
 
 #****************      END NODEJS     ****************************************************
 
@@ -363,7 +370,8 @@ RUN set -ex \
 # Node 12
 ENV NODE_12_VERSION="12.18.0"
 
-RUN  n $NODE_12_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \
+RUN  nodenv install $NODE_12_VERSION && env NODENV_VERSION=$NODE_12_VERSION npm install --save-dev -g -f grunt grunt-cli webpack \
+     && nodenv global $NODE_12_VERSION \
      && rm -rf /tmp/*
 
 #=======================End of layer: runtimes_2  =================

--- a/al2/aarch64/standard/2.0/runtimes.yml
+++ b/al2/aarch64/standard/2.0/runtimes.yml
@@ -91,11 +91,11 @@ runtimes:
       10:
         commands:
           - echo "Installing Node.js version 10 ..."
-          - n $NODE_10_VERSION
+          - nodenv global $NODE_10_VERSION
       12:
         commands:
           - echo "Installing Node.js version 12 ..."
-          - n $NODE_12_VERSION
+          - nodenv global $NODE_12_VERSION
   docker:
     versions:
       19:

--- a/al2/x86_64/standard/1.0/Dockerfile
+++ b/al2/x86_64/standard/1.0/Dockerfile
@@ -128,9 +128,16 @@ RUN set -ex  \
 && chmod +x /usr/local/bin/dotnet-install.sh 
 
 ##nodejs
-ENV N_SRC_DIR="$SRC_DIR/n"
-RUN git clone https://github.com/tj/n $N_SRC_DIR \
-     && cd $N_SRC_DIR && make install
+ENV NODENV_SRC_DIR="/usr/local/nodenv"
+
+ENV PATH="/root/.nodenv/shims:$NODENV_SRC_DIR/bin:$NODENV_SRC_DIR/shims:$PATH" \
+    NODE_BUILD_SRC_DIR="$NODENV_SRC_DIR/plugins/node-build"
+
+RUN set -ex \
+    && git clone https://github.com/nodenv/nodenv.git $NODENV_SRC_DIR \
+    && mkdir -p $NODENV_SRC_DIR/plugins \
+    && git clone https://github.com/nodenv/node-build.git $NODE_BUILD_SRC_DIR \
+    && sh $NODE_BUILD_SRC_DIR/install.sh
 
 ##ruby
 ENV RBENV_SRC_DIR="/usr/local/rbenv"
@@ -303,12 +310,12 @@ RUN set -ex \
 
 ENV NODE_10_VERSION="10.19.0"
 
-RUN  n $NODE_10_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \
+RUN  nodenv install $NODE_10_VERSION && env NODENV_VERSION=$NODE_10_VERSION npm install --save-dev -g -f grunt grunt-cli webpack \
      && curl -sSL https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo \
      && rpm --import https://dl.yarnpkg.com/rpm/pubkey.gpg \
      && yum install -y yarn \
      && yarn --version \
-     && cd / && rm -rf $N_SRC_DIR; rm -rf /tmp/*
+     && rm -rf /tmp/*
 
 #****************      END NODEJS     ****************************************************
 
@@ -411,10 +418,10 @@ RUN set -ex \
 
 #Node 8
 ENV NODE_8_VERSION=8.16.0
-RUN n $NODE_8_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack
+RUN nodenv install $NODE_8_VERSION && env NODENV_VERSION=$NODE_8_VERSION npm install --save-dev -g -f grunt grunt-cli webpack
 
 #Activate the desired runtime versions.
-RUN n $NODE_10_VERSION
+RUN nodenv global $NODE_10_VERSION
 RUN pyenv  global $PYTHON_37_VERSION
 RUN phpenv global $PHP_73_VERSION
 RUN rbenv  global $RUBY_26_VERSION

--- a/al2/x86_64/standard/1.0/runtimes.yml
+++ b/al2/x86_64/standard/1.0/runtimes.yml
@@ -86,11 +86,11 @@ runtimes:
       10:
         commands:
           - echo "Installing Node.js version 10 ..."
-          - n $NODE_10_VERSION
+          - nodenv global $NODE_10_VERSION
       8:
         commands:
           - echo "Installing Node.js version 8 ..."
-          - n $NODE_8_VERSION
+          - nodenv global $NODE_8_VERSION
   docker:
     versions:
       18:

--- a/al2/x86_64/standard/2.0/Dockerfile
+++ b/al2/x86_64/standard/2.0/Dockerfile
@@ -128,9 +128,16 @@ RUN set -ex  \
 && chmod +x /usr/local/bin/dotnet-install.sh 
 
 ##nodejs
-ENV N_SRC_DIR="$SRC_DIR/n"
-RUN git clone https://github.com/tj/n $N_SRC_DIR \
-     && cd $N_SRC_DIR && make install
+ENV NODENV_SRC_DIR="/usr/local/nodenv"
+
+ENV PATH="/root/.nodenv/shims:$NODENV_SRC_DIR/bin:$NODENV_SRC_DIR/shims:$PATH" \
+    NODE_BUILD_SRC_DIR="$NODENV_SRC_DIR/plugins/node-build"
+
+RUN set -ex \
+    && git clone https://github.com/nodenv/nodenv.git $NODENV_SRC_DIR \
+    && mkdir -p $NODENV_SRC_DIR/plugins \
+    && git clone https://github.com/nodenv/node-build.git $NODE_BUILD_SRC_DIR \
+    && sh $NODE_BUILD_SRC_DIR/install.sh
 
 ##ruby
 ENV RBENV_SRC_DIR="/usr/local/rbenv"
@@ -303,12 +310,12 @@ RUN set -ex \
 
 ENV NODE_10_VERSION="10.19.0"
 
-RUN  n $NODE_10_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \
+RUN  nodenv install $NODE_10_VERSION && env NODENV_VERSION=$NODE_10_VERSION npm install --save-dev -g -f grunt grunt-cli webpack \
      && curl -sSL https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo \
      && rpm --import https://dl.yarnpkg.com/rpm/pubkey.gpg \
      && yum install -y yarn \
      && yarn --version \
-     && cd / && rm -rf $N_SRC_DIR; rm -rf /tmp/*
+     && rm -rf /tmp/*
 
 #****************      END NODEJS     ****************************************************
 
@@ -404,7 +411,7 @@ RUN set -ex \
 # Node 12
 ENV NODE_12_VERSION="12.16.1"
 
-RUN  n $NODE_12_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \
+RUN  nodenv install $NODE_12_VERSION && env NODENV_VERSION=$NODE_12_VERSION npm install --save-dev -g -f grunt grunt-cli webpack \
      && rm -rf /tmp/*
 
 #=======================End of layer: runtimes_2  =================
@@ -430,7 +437,7 @@ RUN set -ex \
     && rm -rf /tmp/NuGetScratch
 
 #Activate the desired runtime versions.
-RUN n $NODE_12_VERSION
+RUN nodenv global $NODE_12_VERSION
 RUN rm -rf /root/.pyenv/versions/$PYTHON_37_VERSION
 RUN pyenv  global $PYTHON_38_VERSION
 RUN phpenv global $PHP_73_VERSION

--- a/al2/x86_64/standard/2.0/runtimes.yml
+++ b/al2/x86_64/standard/2.0/runtimes.yml
@@ -86,11 +86,11 @@ runtimes:
       12:
         commands:
           - echo "Installing Node.js version 12 ..."
-          - n $NODE_12_VERSION
+          - nodenv global $NODE_12_VERSION
       10:
         commands:
           - echo "Installing Node.js version 10 ..."
-          - n $NODE_10_VERSION
+          - nodenv global $NODE_10_VERSION
   docker:
     versions:
       18:

--- a/al2/x86_64/standard/3.0/Dockerfile
+++ b/al2/x86_64/standard/3.0/Dockerfile
@@ -129,9 +129,16 @@ RUN set -ex  \
 && chmod +x /usr/local/bin/dotnet-install.sh 
 
 ##nodejs
-ENV N_SRC_DIR="$SRC_DIR/n"
-RUN git clone https://github.com/tj/n $N_SRC_DIR \
-     && cd $N_SRC_DIR && make install
+ENV NODENV_SRC_DIR="/usr/local/nodenv"
+
+ENV PATH="/root/.nodenv/shims:$NODENV_SRC_DIR/bin:$NODENV_SRC_DIR/shims:$PATH" \
+    NODE_BUILD_SRC_DIR="$NODENV_SRC_DIR/plugins/node-build"
+
+RUN set -ex \
+    && git clone https://github.com/nodenv/nodenv.git $NODENV_SRC_DIR \
+    && mkdir -p $NODENV_SRC_DIR/plugins \
+    && git clone https://github.com/nodenv/node-build.git $NODE_BUILD_SRC_DIR \
+    && sh $NODE_BUILD_SRC_DIR/install.sh
 
 ##ruby
 ENV RBENV_SRC_DIR="/usr/local/rbenv"
@@ -296,12 +303,12 @@ RUN set -ex \
 
 ENV NODE_10_VERSION="10.21.0"
 
-RUN  n $NODE_10_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \
+RUN  nodenv install $NODE_10_VERSION && env NODENV_VERSION=$NODE_10_VERSION npm install --save-dev -g -f grunt grunt-cli webpack \
      && curl -sSL https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo \
      && rpm --import https://dl.yarnpkg.com/rpm/pubkey.gpg \
      && yum install -y yarn \
      && yarn --version \
-     && cd / && rm -rf $N_SRC_DIR; rm -rf /tmp/*
+     && rm -rf /tmp/*
 
 #****************      END NODEJS     ****************************************************
 
@@ -397,7 +404,8 @@ RUN set -ex \
 # Node 12
 ENV NODE_12_VERSION="12.18.0"
 
-RUN  n $NODE_12_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \
+RUN  nodenv install $NODE_12_VERSION && env NODENV_VERSION=$NODE_12_VERSION npm install --save-dev -g -f grunt grunt-cli webpack \
+     && nodenv global $NODE_12_VERSION \
      && rm -rf /tmp/*
 
 #=======================End of layer: runtimes_2  =================

--- a/al2/x86_64/standard/3.0/runtimes.yml
+++ b/al2/x86_64/standard/3.0/runtimes.yml
@@ -102,11 +102,11 @@ runtimes:
       10:
         commands:
           - echo "Installing Node.js version 10 ..."
-          - n $NODE_10_VERSION
+          - nodenv global $NODE_10_VERSION
       12:
         commands:
           - echo "Installing Node.js version 12 ..."
-          - n $NODE_12_VERSION
+          - nodenv global $NODE_12_VERSION
   docker:
     versions:
       18:

--- a/ubuntu/standard/1.0/Dockerfile
+++ b/ubuntu/standard/1.0/Dockerfile
@@ -138,10 +138,16 @@ RUN set -ex  \
 && chmod +x /usr/local/bin/dotnet-install.sh 
 
 #nodejs
-ENV SRC_DIR="/usr/src"
-ENV N_SRC_DIR="$SRC_DIR/n"
-RUN git clone https://github.com/tj/n $N_SRC_DIR \
-     && cd $N_SRC_DIR && make install 
+ENV NODENV_SRC_DIR="/usr/local/nodenv"
+
+ENV PATH="/root/.nodenv/shims:$NODENV_SRC_DIR/bin:$NODENV_SRC_DIR/shims:$PATH" \
+    NODE_BUILD_SRC_DIR="$NODENV_SRC_DIR/plugins/node-build"
+
+RUN set -ex \
+    && git clone https://github.com/nodenv/nodenv.git $NODENV_SRC_DIR \
+    && mkdir -p $NODENV_SRC_DIR/plugins \
+    && git clone https://github.com/nodenv/node-build.git $NODE_BUILD_SRC_DIR \
+    && sh $NODE_BUILD_SRC_DIR/install.sh
 
 #ruby
 ENV RBENV_SRC_DIR="/usr/local/rbenv"
@@ -212,13 +218,13 @@ RUN set -ex \
 ENV NODE_12_VERSION="12.16.1" \
     NODE_10_VERSION="10.19.0"
 
-RUN     n $NODE_10_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \
-     && n $NODE_12_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \
+RUN     nodenv install $NODE_10_VERSION && env NODENV_VERSION=$NODE_10_VERSION npm install --save-dev -g -f grunt grunt-cli webpack \
+     && nodenv install $NODE_12_VERSION && env NODENV_VERSION=$NODE_12_VERSION npm install --save-dev -g -f grunt grunt-cli webpack \
      && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
      && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
      && apt-get update && apt-get install -y --no-install-recommends yarn \
      && yarn --version \
-     && cd / && rm -rf $N_SRC_DIR;rm -rf /tmp/*
+     && rm -rf /tmp/*
 
 
 #****************      END NODEJS     ****************************************************
@@ -428,7 +434,7 @@ FROM runtimes_n_openjdk AS std_v1
 
 #Prune nonactive runtimes.
 RUN rm  -rf /root/.dotnet/sdk/*
-RUN n rm $NODE_12_VERSION
+RUN nodenv uninstall -f $NODE_12_VERSION
 RUN goenv  uninstall -f $GOLANG_12_VERSION
 RUN goenv  uninstall -f $GOLANG_13_VERSION
 RUN phpenv uninstall -f $PHP_74_VERSION
@@ -490,7 +496,7 @@ RUN set -ex \
 
 #Node 8
 ENV NODE_8_VERSION=8.11.0
-RUN n $NODE_8_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack
+RUN nodenv install $NODE_8_VERSION && env NODENV_VERSION=$NODE_8_VERSION npm install --save-dev -g -f grunt grunt-cli webpack
 
 #Golang 1.11
 ENV GOLANG_11_VERSION=1.11.4
@@ -498,7 +504,7 @@ RUN goenv install $GOLANG_11_VERSION; rm -rf /tmp/*
 RUN goenv  global $GOLANG_11_VERSION
 
 #Activate the desired runtime versions.
-RUN n $NODE_10_VERSION
+RUN nodenv global $NODE_10_VERSION
 RUN pyenv  global $PYTHON_37_VERSION
 RUN phpenv global $PHP_73_VERSION
 RUN rbenv  global $RUBY_26_VERSION

--- a/ubuntu/standard/2.0/Dockerfile
+++ b/ubuntu/standard/2.0/Dockerfile
@@ -138,10 +138,16 @@ RUN set -ex  \
 && chmod +x /usr/local/bin/dotnet-install.sh 
 
 #nodejs
-ENV SRC_DIR="/usr/src"
-ENV N_SRC_DIR="$SRC_DIR/n"
-RUN git clone https://github.com/tj/n $N_SRC_DIR \
-     && cd $N_SRC_DIR && make install 
+ENV NODENV_SRC_DIR="/usr/local/nodenv"
+
+ENV PATH="/root/.nodenv/shims:$NODENV_SRC_DIR/bin:$NODENV_SRC_DIR/shims:$PATH" \
+    NODE_BUILD_SRC_DIR="$NODENV_SRC_DIR/plugins/node-build"
+
+RUN set -ex \
+    && git clone https://github.com/nodenv/nodenv.git $NODENV_SRC_DIR \
+    && mkdir -p $NODENV_SRC_DIR/plugins \
+    && git clone https://github.com/nodenv/node-build.git $NODE_BUILD_SRC_DIR \
+    && sh $NODE_BUILD_SRC_DIR/install.sh
 
 #ruby
 ENV RBENV_SRC_DIR="/usr/local/rbenv"
@@ -212,13 +218,13 @@ RUN set -ex \
 ENV NODE_12_VERSION="12.16.1" \
     NODE_10_VERSION="10.19.0"
 
-RUN     n $NODE_10_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \
-     && n $NODE_12_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \
+RUN     nodenv install $NODE_10_VERSION && env NODENV_VERSION=$NODE_10_VERSION npm install --save-dev -g -f grunt grunt-cli webpack \
+     && nodenv install $NODE_12_VERSION && env NODENV_VERSION=$NODE_12_VERSION npm install --save-dev -g -f grunt grunt-cli webpack \
      && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
      && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
      && apt-get update && apt-get install -y --no-install-recommends yarn \
      && yarn --version \
-     && cd / && rm -rf $N_SRC_DIR;rm -rf /tmp/*
+     && rm -rf /tmp/*
 
 #****************      END NODEJS     ****************************************************
 
@@ -427,7 +433,7 @@ FROM runtimes_n_openjdk AS std_v2
 
 #Prune nonactive runtimes.
 RUN rm  -rf /root/.dotnet/sdk/*
-RUN n rm $NODE_12_VERSION
+RUN nodenv uninstall -f $NODE_12_VERSION
 RUN phpenv uninstall -f $PHP_74_VERSION
 RUN pyenv  uninstall -f $PYTHON_38_VERSION
 RUN rbenv  uninstall -f $RUBY_27_VERSION
@@ -487,10 +493,10 @@ RUN set -ex \
 
 #Node 8
 ENV NODE_8_VERSION=8.16.0
-RUN n $NODE_8_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack
+RUN nodenv install $NODE_8_VERSION && env NODENV_VERSION=$NODE_8_VERSION npm install --save-dev -g -f grunt grunt-cli webpack
 
 #Activate the desired runtime versions.
-RUN n $NODE_10_VERSION
+RUN nodenv global $NODE_10_VERSION
 RUN pyenv  global $PYTHON_37_VERSION
 RUN phpenv global $PHP_73_VERSION
 RUN rbenv  global $RUBY_26_VERSION

--- a/ubuntu/standard/2.0/runtimes.yml
+++ b/ubuntu/standard/2.0/runtimes.yml
@@ -87,11 +87,11 @@ runtimes:
       10:
         commands:
           - echo "Installing Node.js version 10 ..."
-          - n $NODE_10_VERSION
+          - nodenv global $NODE_10_VERSION
       8:
         commands:
           - echo "Installing Node.js version 8 ..."
-          - n $NODE_8_VERSION
+          - nodenv global $NODE_8_VERSION
   docker:
     versions:
       18:

--- a/ubuntu/standard/3.0/Dockerfile
+++ b/ubuntu/standard/3.0/Dockerfile
@@ -138,10 +138,16 @@ RUN set -ex  \
 && chmod +x /usr/local/bin/dotnet-install.sh 
 
 #nodejs
-ENV SRC_DIR="/usr/src"
-ENV N_SRC_DIR="$SRC_DIR/n"
-RUN git clone https://github.com/tj/n $N_SRC_DIR \
-     && cd $N_SRC_DIR && make install 
+ENV NODENV_SRC_DIR="/usr/local/nodenv"
+
+ENV PATH="/root/.nodenv/shims:$NODENV_SRC_DIR/bin:$NODENV_SRC_DIR/shims:$PATH" \
+    NODE_BUILD_SRC_DIR="$NODENV_SRC_DIR/plugins/node-build"
+
+RUN set -ex \
+    && git clone https://github.com/nodenv/nodenv.git $NODENV_SRC_DIR \
+    && mkdir -p $NODENV_SRC_DIR/plugins \
+    && git clone https://github.com/nodenv/node-build.git $NODE_BUILD_SRC_DIR \
+    && sh $NODE_BUILD_SRC_DIR/install.sh
 
 #ruby
 ENV RBENV_SRC_DIR="/usr/local/rbenv"
@@ -209,16 +215,16 @@ RUN set -ex \
 
 #****************      NODEJS     ****************************************************
 
-ENV NODE_12_VERSION="12.16.1" \
-    NODE_10_VERSION="10.19.0"
+ENV NODE_10_VERSION="10.19.0" \
+    NODE_12_VERSION="12.16.1"
 
-RUN     n $NODE_10_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \
-     && n $NODE_12_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \
+RUN     nodenv install $NODE_10_VERSION && env NODENV_VERSION=$NODE_10_VERSION npm install --save-dev -g -f grunt grunt-cli webpack \
+     && nodenv install $NODE_12_VERSION && env NODENV_VERSION=$NODE_12_VERSION npm install --save-dev -g -f grunt grunt-cli webpack \
      && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
      && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
      && apt-get update && apt-get install -y --no-install-recommends yarn \
      && yarn --version \
-     && cd / && rm -rf $N_SRC_DIR;rm -rf /tmp/*
+     && rm -rf /tmp/*
 
 #****************      END NODEJS     ****************************************************
 
@@ -485,7 +491,7 @@ RUN set -ex \
     && ln -s ~/.dotnet/tools/dotnet-gitversion /usr/local/bin/gitversion
 
 #Activate the desired runtime versions.
-RUN n $NODE_12_VERSION
+RUN nodenv global $NODE_12_VERSION
 RUN pyenv  global $PYTHON_38_VERSION
 RUN phpenv global $PHP_73_VERSION
 RUN rbenv  global $RUBY_26_VERSION

--- a/ubuntu/standard/3.0/Dockerfile
+++ b/ubuntu/standard/3.0/Dockerfile
@@ -215,8 +215,8 @@ RUN set -ex \
 
 #****************      NODEJS     ****************************************************
 
-ENV NODE_10_VERSION="10.19.0" \
-    NODE_12_VERSION="12.16.1"
+ENV NODE_12_VERSION="12.16.1" \
+    NODE_10_VERSION="10.19.0"
 
 RUN     nodenv install $NODE_10_VERSION && env NODENV_VERSION=$NODE_10_VERSION npm install --save-dev -g -f grunt grunt-cli webpack \
      && nodenv install $NODE_12_VERSION && env NODENV_VERSION=$NODE_12_VERSION npm install --save-dev -g -f grunt grunt-cli webpack \

--- a/ubuntu/standard/3.0/runtimes.yml
+++ b/ubuntu/standard/3.0/runtimes.yml
@@ -87,11 +87,11 @@ runtimes:
       10:
         commands:
           - echo "Installing Node.js version 10 ..."
-          - n $NODE_10_VERSION
+          - nodenv global $NODE_10_VERSION
       12:
         commands:
           - echo "Installing Node.js version 12 ..."
-          - n $NODE_12_VERSION
+          - nodenv global $NODE_12_VERSION
   docker:
     versions:
       18:

--- a/ubuntu/standard/4.0/Dockerfile
+++ b/ubuntu/standard/4.0/Dockerfile
@@ -139,10 +139,16 @@ RUN set -ex  \
 && chmod +x /usr/local/bin/dotnet-install.sh 
 
 #nodejs
-ENV SRC_DIR="/usr/src"
-ENV N_SRC_DIR="$SRC_DIR/n"
-RUN git clone https://github.com/tj/n $N_SRC_DIR \
-     && cd $N_SRC_DIR && make install 
+ENV NODENV_SRC_DIR="/usr/local/nodenv"
+
+ENV PATH="/root/.nodenv/shims:$NODENV_SRC_DIR/bin:$NODENV_SRC_DIR/shims:$PATH" \
+    NODE_BUILD_SRC_DIR="$NODENV_SRC_DIR/plugins/node-build"
+
+RUN set -ex \
+    && git clone https://github.com/nodenv/nodenv.git $NODENV_SRC_DIR \
+    && mkdir -p $NODENV_SRC_DIR/plugins \
+    && git clone https://github.com/nodenv/node-build.git $NODE_BUILD_SRC_DIR \
+    && sh $NODE_BUILD_SRC_DIR/install.sh
 
 #ruby
 ENV RBENV_SRC_DIR="/usr/local/rbenv"
@@ -220,13 +226,13 @@ RUN set -ex \
 ENV NODE_12_VERSION="12.18.0" \
     NODE_10_VERSION="10.21.0"
 
-RUN     n $NODE_10_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \
-     && n $NODE_12_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \
+RUN     nodenv install $NODE_10_VERSION && env NODENV_VERSION=$NODE_10_VERSION npm install --save-dev -g -f grunt grunt-cli webpack \
+     && nodenv install $NODE_12_VERSION && env NODENV_VERSION=$NODE_12_VERSION npm install --save-dev -g -f grunt grunt-cli webpack \
      && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
      && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
      && apt-get update && apt-get install -y --no-install-recommends yarn \
      && yarn --version \
-     && cd / && rm -rf $N_SRC_DIR;rm -rf /tmp/*
+     && rm -rf /tmp/*
 
 #****************      END NODEJS     ****************************************************
 
@@ -463,7 +469,7 @@ RUN goenv install $GOLANG_14_VERSION; rm -rf /tmp/*; \
     goenv global  $GOLANG_14_VERSION
 
 # Activate runtime versions specific to image version.
-RUN n $NODE_12_VERSION
+RUN nodenv global $NODE_12_VERSION
 RUN pyenv  global $PYTHON_38_VERSION
 RUN phpenv global $PHP_74_VERSION
 RUN rbenv  global $RUBY_27_VERSION

--- a/ubuntu/standard/4.0/runtimes.yml
+++ b/ubuntu/standard/4.0/runtimes.yml
@@ -103,11 +103,11 @@ runtimes:
       10:
         commands:
           - echo "Installing Node.js version 10 ..."
-          - n $NODE_10_VERSION
+          - nodenv global $NODE_10_VERSION
       12:
         commands:
           - echo "Installing Node.js version 12 ..."
-          - n $NODE_12_VERSION
+          - nodenv global $NODE_12_VERSION
   docker:
     versions:
       18:


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Changed the `Node.js` version manager from `n` to `nodenv` in order to be more like many of the other installed version managers which use a unified syntax based on that of `rbenv`, such as `goenv`, `pyenv` & `phpenv`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
