### PR TITLE
Use public ECR for images that exist there.

### DIFF
--- a/al2/aarch64/standard/1.0/Dockerfile
+++ b/al2/aarch64/standard/1.0/Dockerfile
@@ -9,7 +9,7 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-FROM amazonlinux:2
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
 
 ENV RUBY_VERSION="2.6.5" \
  PYTHON_37_VERSION="3.7.4" \

--- a/al2/aarch64/standard/2.0/Dockerfile
+++ b/al2/aarch64/standard/2.0/Dockerfile
@@ -9,7 +9,7 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-FROM amazonlinux:2 AS core
+FROM public.ecr.aws/amazonlinux/amazonlinux:2 AS core
 
 ENV EPEL_REPO="https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
 

--- a/al2/x86_64/standard/1.0/Dockerfile
+++ b/al2/x86_64/standard/1.0/Dockerfile
@@ -9,7 +9,7 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-FROM amazonlinux:2 AS core
+FROM public.ecr.aws/amazonlinux/amazonlinux:2 AS core
 
 ENV EPEL_REPO="https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
 

--- a/al2/x86_64/standard/2.0/Dockerfile
+++ b/al2/x86_64/standard/2.0/Dockerfile
@@ -9,7 +9,7 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-FROM amazonlinux:2 AS core
+FROM public.ecr.aws/amazonlinux/amazonlinux:2 AS core
 
 ENV EPEL_REPO="https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
 

--- a/al2/x86_64/standard/3.0/Dockerfile
+++ b/al2/x86_64/standard/3.0/Dockerfile
@@ -9,7 +9,7 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-FROM amazonlinux:2 AS core
+FROM public.ecr.aws/amazonlinux/amazonlinux:2 AS core
 
 ENV EPEL_REPO="https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
 

--- a/ubuntu/standard/1.0/Dockerfile
+++ b/ubuntu/standard/1.0/Dockerfile
@@ -9,7 +9,7 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-FROM ubuntu:18.04 AS core
+FROM public.ecr.aws/ubuntu/ubuntu:18.04 AS core
 
 ENV DEBIAN_FRONTEND="noninteractive"
 

--- a/ubuntu/standard/2.0/Dockerfile
+++ b/ubuntu/standard/2.0/Dockerfile
@@ -9,7 +9,7 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-FROM ubuntu:18.04 AS core
+FROM public.ecr.aws/ubuntu/ubuntu:18.04 AS core
 
 ENV DEBIAN_FRONTEND="noninteractive"
 

--- a/ubuntu/standard/3.0/Dockerfile
+++ b/ubuntu/standard/3.0/Dockerfile
@@ -9,7 +9,7 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-FROM ubuntu:18.04 AS core
+FROM public.ecr.aws/ubuntu/ubuntu:18.04 AS core
 
 ENV DEBIAN_FRONTEND="noninteractive"
 

--- a/ubuntu/standard/4.0/Dockerfile
+++ b/ubuntu/standard/4.0/Dockerfile
@@ -9,7 +9,7 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-FROM ubuntu:18.04 AS core
+FROM public.ecr.aws/ubuntu/ubuntu:18.04 AS core
 
 ENV DEBIAN_FRONTEND="noninteractive"
 

--- a/ubuntu/standard/5.0/Dockerfile
+++ b/ubuntu/standard/5.0/Dockerfile
@@ -9,7 +9,7 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-FROM ubuntu:20.04 AS core
+FROM public.ecr.aws/ubuntu/ubuntu:20.04 AS core
 
 ARG DEBIAN_FRONTEND="noninteractive"
 


### PR DESCRIPTION
This changeset adds the AWS public ECR to the image sources (for image tags that are actually hosted there).

This should make builds of these images, and specifically, builds of these images in CodeBuild pipelines, succeed more reliably.

This MR prompted by my pipeline that builds the CodeBuild images (because the CodeBuild images are **not** in the ECR Public repo) failing out b/c of Docker rate limits.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
