### PR TITLE
bump dotnet 5 version

### DIFF
--- a/ubuntu/standard/5.0/Dockerfile
+++ b/ubuntu/standard/5.0/Dockerfile
@@ -158,7 +158,7 @@ FROM tools AS runtimes
 #****************     .NET-CORE     *******************************************************
 
 ENV DOTNET_31_SDK_VERSION="3.1.404"
-ENV DOTNET_5_SDK_VERSION="5.0.101"
+ENV DOTNET_5_SDK_VERSION="5.0.200"
 ARG DOTNET_ROOT="/root/.dotnet"
 
 # Add .NET Core 3.1 Global Tools install folder to PATH


### PR DESCRIPTION
*Description of changes:*
Dotnet version is 5.0.101, however Microsoft released 5.0.200 yesterday (03/02/2021) and it breaks builds as ver. 5.0.101 doesn't seem to be supported anymore.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
