### PR TITLE
Update codebuild_build.sh to use local image name override

### DIFF
--- a/local_builds/codebuild_build.sh
+++ b/local_builds/codebuild_build.sh
@@ -182,7 +182,12 @@ else
     docker_command+=" -e \"INITIATOR=$USER\""
 fi
 
-docker_command+=" amazon/aws-codebuild-local:latest"
+if [ -n $local_agent_image ]
+then
+    docker_command+=" $local_agent_image"
+else
+    docker_command+=" amazon/aws-codebuild-local:latest"
+fi
 
 # Note we do not expose the AWS_SECRET_ACCESS_KEY or the AWS_SESSION_TOKEN
 exposed_command=$docker_command


### PR DESCRIPTION
Issue: https://github.com/aws/aws-codebuild-docker-images/issues/284

Update script to use alternative local agent image name if provided as CLI argument. This change is required to allow use of the local agent image tagged with :aarch64 instead of :latest

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
