### PR TITLE
Add quotes around local_agent_image

### DIFF
--- a/local_builds/codebuild_build.sh
+++ b/local_builds/codebuild_build.sh
@@ -182,7 +182,7 @@ else
     docker_command+=" -e \"INITIATOR=$USER\""
 fi
 
-if [ -n $local_agent_image ]
+if [ -n "$local_agent_image" ]
 then
     docker_command+=" $local_agent_image"
 else


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add quotes in if statement around `$local_agent_image`. Matches formatting in the rest of the script and gives expected behavior.

This script was running as expected yesterday but after re-downloading it I was getting an error that said `"docker run" requires at least 1 argument.` This change returns the script to expected behavior when running without the `-l` flag

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
