### PR TITLE
Remove ldflags_dirs step. Fixes #460

### DIFF
--- a/al2/aarch64/standard/2.0/tools/runtime_configs/python/3.7.7
+++ b/al2/aarch64/standard/2.0/tools/runtime_configs/python/3.7.7
@@ -11,9 +11,9 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.7.7" "https://www.python.org/ftp/python/3.7.7/Python-3.7.7.tar.xz#06a0a9f1bf0d8cd1e4121194d666c4e28ddae4dd54346de6c343206599f02136" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.7.7" "https://www.python.org/ftp/python/3.7.7/Python-3.7.7.tar.xz#06a0a9f1bf0d8cd1e4121194d666c4e28ddae4dd54346de6c343206599f02136" standard verify_py37 copy_python_gdb ensurepip
 else
-  install_package "Python-3.7.7" "https://www.python.org/ftp/python/3.7.7/Python-3.7.7.tgz#8c8be91cd2648a1a0c251f04ea0bb4c2a5570feb9c45eaaa2241c785585b475a" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.7.7" "https://www.python.org/ftp/python/3.7.7/Python-3.7.7.tgz#8c8be91cd2648a1a0c251f04ea0bb4c2a5570feb9c45eaaa2241c785585b475a" standard verify_py37 copy_python_gdb ensurepip
 fi
 
 

--- a/al2/aarch64/standard/2.0/tools/runtime_configs/python/3.8.3
+++ b/al2/aarch64/standard/2.0/tools/runtime_configs/python/3.8.3
@@ -11,9 +11,9 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.8.3" "https://www.python.org/ftp/python/3.8.3/Python-3.8.3.tar.xz#dfab5ec723c218082fe3d5d7ae17ecbdebffa9a1aea4d64aa3a2ecdd2e795864" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip
+  install_package "Python-3.8.3" "https://www.python.org/ftp/python/3.8.3/Python-3.8.3.tar.xz#dfab5ec723c218082fe3d5d7ae17ecbdebffa9a1aea4d64aa3a2ecdd2e795864" standard verify_py38 copy_python_gdb ensurepip
 else
-  install_package "Python-3.8.3" "https://www.python.org/ftp/python/3.8.3/Python-3.8.3.tgz#6af6d4d2e010f9655518d0fc6738c7ff7069f10a4d2fbd55509e467f092a8b90" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip
+  install_package "Python-3.8.3" "https://www.python.org/ftp/python/3.8.3/Python-3.8.3.tgz#6af6d4d2e010f9655518d0fc6738c7ff7069f10a4d2fbd55509e467f092a8b90" standard verify_py38 copy_python_gdb ensurepip
 fi
 
 

--- a/al2/x86_64/standard/2.0/tools/runtime_configs/python/3.7.10
+++ b/al2/x86_64/standard/2.0/tools/runtime_configs/python/3.7.10
@@ -11,9 +11,9 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.7.10" "https://www.python.org/ftp/python/3.7.10/Python-3.7.10.tar.xz#f8d82e7572c86ec9d55c8627aae5040124fd2203af400c383c821b980306ee6b" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.7.10" "https://www.python.org/ftp/python/3.7.10/Python-3.7.10.tar.xz#f8d82e7572c86ec9d55c8627aae5040124fd2203af400c383c821b980306ee6b" standard verify_py37 copy_python_gdb ensurepip
 else
-  install_package "Python-3.7.10" "https://www.python.org/ftp/python/3.7.10/Python-3.7.10.tgz#c9649ad84dc3a434c8637df6963100b2e5608697f9ba56d82e3809e4148e0975" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.7.10" "https://www.python.org/ftp/python/3.7.10/Python-3.7.10.tgz#c9649ad84dc3a434c8637df6963100b2e5608697f9ba56d82e3809e4148e0975" standard verify_py37 copy_python_gdb ensurepip
 fi
 
 

--- a/al2/x86_64/standard/2.0/tools/runtime_configs/python/3.8.8
+++ b/al2/x86_64/standard/2.0/tools/runtime_configs/python/3.8.8
@@ -11,9 +11,9 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.1i" "https://www.openssl.org/source/old/1.1.1/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.8.8" "https://www.python.org/ftp/python/3.8.8/Python-3.8.8.tar.xz#7c664249ff77e443d6ea0e4cf0e587eae918ca3c48d081d1915fe2a1f1bcc5cc" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip
+  install_package "Python-3.8.8" "https://www.python.org/ftp/python/3.8.8/Python-3.8.8.tar.xz#7c664249ff77e443d6ea0e4cf0e587eae918ca3c48d081d1915fe2a1f1bcc5cc" standard verify_py38 copy_python_gdb ensurepip
 else
-  install_package "Python-3.8.8" "https://www.python.org/ftp/python/3.8.8/Python-3.8.8.tgz#76c0763f048e4f9b861d24da76b7dd5c7a3ba7ec086f40caedeea359263276f7" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip
+  install_package "Python-3.8.8" "https://www.python.org/ftp/python/3.8.8/Python-3.8.8.tgz#76c0763f048e4f9b861d24da76b7dd5c7a3ba7ec086f40caedeea359263276f7" standard verify_py38 copy_python_gdb ensurepip
 fi
 
 

--- a/al2/x86_64/standard/3.0/tools/runtime_configs/python/3.7.10
+++ b/al2/x86_64/standard/3.0/tools/runtime_configs/python/3.7.10
@@ -11,9 +11,9 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.7.10" "https://www.python.org/ftp/python/3.7.10/Python-3.7.10.tar.xz#f8d82e7572c86ec9d55c8627aae5040124fd2203af400c383c821b980306ee6b" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.7.10" "https://www.python.org/ftp/python/3.7.10/Python-3.7.10.tar.xz#f8d82e7572c86ec9d55c8627aae5040124fd2203af400c383c821b980306ee6b" standard verify_py37 copy_python_gdb ensurepip
 else
-  install_package "Python-3.7.10" "https://www.python.org/ftp/python/3.7.10/Python-3.7.10.tgz#c9649ad84dc3a434c8637df6963100b2e5608697f9ba56d82e3809e4148e0975" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.7.10" "https://www.python.org/ftp/python/3.7.10/Python-3.7.10.tgz#c9649ad84dc3a434c8637df6963100b2e5608697f9ba56d82e3809e4148e0975" standard verify_py37 copy_python_gdb ensurepip
 fi
 
 

--- a/al2/x86_64/standard/3.0/tools/runtime_configs/python/3.8.8
+++ b/al2/x86_64/standard/3.0/tools/runtime_configs/python/3.8.8
@@ -11,9 +11,9 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.1i" "https://www.openssl.org/source/old/1.1.1/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.8.8" "https://www.python.org/ftp/python/3.8.8/Python-3.8.8.tar.xz#7c664249ff77e443d6ea0e4cf0e587eae918ca3c48d081d1915fe2a1f1bcc5cc" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip
+  install_package "Python-3.8.8" "https://www.python.org/ftp/python/3.8.8/Python-3.8.8.tar.xz#7c664249ff77e443d6ea0e4cf0e587eae918ca3c48d081d1915fe2a1f1bcc5cc" standard verify_py38 copy_python_gdb ensurepip
 else
-  install_package "Python-3.8.8" "https://www.python.org/ftp/python/3.8.8/Python-3.8.8.tgz#76c0763f048e4f9b861d24da76b7dd5c7a3ba7ec086f40caedeea359263276f7" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip
+  install_package "Python-3.8.8" "https://www.python.org/ftp/python/3.8.8/Python-3.8.8.tgz#76c0763f048e4f9b861d24da76b7dd5c7a3ba7ec086f40caedeea359263276f7" standard verify_py38 copy_python_gdb ensurepip
 fi
 
 

--- a/ubuntu/standard/3.0/tools/runtime_configs/python/3.7.10
+++ b/ubuntu/standard/3.0/tools/runtime_configs/python/3.7.10
@@ -11,9 +11,9 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.7.10" "https://www.python.org/ftp/python/3.7.10/Python-3.7.10.tar.xz#f8d82e7572c86ec9d55c8627aae5040124fd2203af400c383c821b980306ee6b" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.7.10" "https://www.python.org/ftp/python/3.7.10/Python-3.7.10.tar.xz#f8d82e7572c86ec9d55c8627aae5040124fd2203af400c383c821b980306ee6b" standard verify_py37 copy_python_gdb ensurepip
 else
-  install_package "Python-3.7.10" "https://www.python.org/ftp/python/3.7.10/Python-3.7.10.tgz#c9649ad84dc3a434c8637df6963100b2e5608697f9ba56d82e3809e4148e0975" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.7.10" "https://www.python.org/ftp/python/3.7.10/Python-3.7.10.tgz#c9649ad84dc3a434c8637df6963100b2e5608697f9ba56d82e3809e4148e0975" standard verify_py37 copy_python_gdb ensurepip
 fi
 
 

--- a/ubuntu/standard/3.0/tools/runtime_configs/python/3.8.8
+++ b/ubuntu/standard/3.0/tools/runtime_configs/python/3.8.8
@@ -11,9 +11,9 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.1i" "https://www.openssl.org/source/old/1.1.1/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.8.8" "https://www.python.org/ftp/python/3.8.8/Python-3.8.8.tar.xz#7c664249ff77e443d6ea0e4cf0e587eae918ca3c48d081d1915fe2a1f1bcc5cc" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip
+  install_package "Python-3.8.8" "https://www.python.org/ftp/python/3.8.8/Python-3.8.8.tar.xz#7c664249ff77e443d6ea0e4cf0e587eae918ca3c48d081d1915fe2a1f1bcc5cc" standard verify_py38 copy_python_gdb ensurepip
 else
-  install_package "Python-3.8.8" "https://www.python.org/ftp/python/3.8.8/Python-3.8.8.tgz#76c0763f048e4f9b861d24da76b7dd5c7a3ba7ec086f40caedeea359263276f7" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip
+  install_package "Python-3.8.8" "https://www.python.org/ftp/python/3.8.8/Python-3.8.8.tgz#76c0763f048e4f9b861d24da76b7dd5c7a3ba7ec086f40caedeea359263276f7" standard verify_py38 copy_python_gdb ensurepip
 fi
 
 

--- a/ubuntu/standard/4.0/tools/runtime_configs/python/3.7.10
+++ b/ubuntu/standard/4.0/tools/runtime_configs/python/3.7.10
@@ -11,9 +11,9 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.7.10" "https://www.python.org/ftp/python/3.7.10/Python-3.7.10.tar.xz#f8d82e7572c86ec9d55c8627aae5040124fd2203af400c383c821b980306ee6b" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.7.10" "https://www.python.org/ftp/python/3.7.10/Python-3.7.10.tar.xz#f8d82e7572c86ec9d55c8627aae5040124fd2203af400c383c821b980306ee6b" standard verify_py37 copy_python_gdb ensurepip
 else
-  install_package "Python-3.7.10" "https://www.python.org/ftp/python/3.7.10/Python-3.7.10.tgz#c9649ad84dc3a434c8637df6963100b2e5608697f9ba56d82e3809e4148e0975" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.7.10" "https://www.python.org/ftp/python/3.7.10/Python-3.7.10.tgz#c9649ad84dc3a434c8637df6963100b2e5608697f9ba56d82e3809e4148e0975" standard verify_py37 copy_python_gdb ensurepip
 fi
 
 

--- a/ubuntu/standard/4.0/tools/runtime_configs/python/3.8.8
+++ b/ubuntu/standard/4.0/tools/runtime_configs/python/3.8.8
@@ -11,9 +11,9 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.1i" "https://www.openssl.org/source/old/1.1.1/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.8.8" "https://www.python.org/ftp/python/3.8.8/Python-3.8.8.tar.xz#7c664249ff77e443d6ea0e4cf0e587eae918ca3c48d081d1915fe2a1f1bcc5cc" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip
+  install_package "Python-3.8.8" "https://www.python.org/ftp/python/3.8.8/Python-3.8.8.tar.xz#7c664249ff77e443d6ea0e4cf0e587eae918ca3c48d081d1915fe2a1f1bcc5cc" standard verify_py38 copy_python_gdb ensurepip
 else
-  install_package "Python-3.8.8" "https://www.python.org/ftp/python/3.8.8/Python-3.8.8.tgz#76c0763f048e4f9b861d24da76b7dd5c7a3ba7ec086f40caedeea359263276f7" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip
+  install_package "Python-3.8.8" "https://www.python.org/ftp/python/3.8.8/Python-3.8.8.tgz#76c0763f048e4f9b861d24da76b7dd5c7a3ba7ec086f40caedeea359263276f7" standard verify_py38 copy_python_gdb ensurepip
 fi
 
 

--- a/ubuntu/standard/5.0/tools/runtime_configs/python/3.7.10
+++ b/ubuntu/standard/5.0/tools/runtime_configs/python/3.7.10
@@ -11,8 +11,8 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.7.10" "https://www.python.org/ftp/python/3.7.10/Python-3.7.10.tar.xz#f8d82e7572c86ec9d55c8627aae5040124fd2203af400c383c821b980306ee6b" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.7.10" "https://www.python.org/ftp/python/3.7.10/Python-3.7.10.tar.xz#f8d82e7572c86ec9d55c8627aae5040124fd2203af400c383c821b980306ee6b" standard verify_py37 copy_python_gdb ensurepip
 else
-  install_package "Python-3.7.10" "https://www.python.org/ftp/python/3.7.10/Python-3.7.10.tgz#c9649ad84dc3a434c8637df6963100b2e5608697f9ba56d82e3809e4148e0975" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.7.10" "https://www.python.org/ftp/python/3.7.10/Python-3.7.10.tgz#c9649ad84dc3a434c8637df6963100b2e5608697f9ba56d82e3809e4148e0975" standard verify_py37 copy_python_gdb ensurepip
 fi
 

--- a/ubuntu/standard/5.0/tools/runtime_configs/python/3.8.8
+++ b/ubuntu/standard/5.0/tools/runtime_configs/python/3.8.8
@@ -11,7 +11,7 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.1i" "https://www.openssl.org/source/old/1.1.1/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.8.8" "https://www.python.org/ftp/python/3.8.8/Python-3.8.8.tar.xz#7c664249ff77e443d6ea0e4cf0e587eae918ca3c48d081d1915fe2a1f1bcc5cc" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip
+  install_package "Python-3.8.8" "https://www.python.org/ftp/python/3.8.8/Python-3.8.8.tar.xz#7c664249ff77e443d6ea0e4cf0e587eae918ca3c48d081d1915fe2a1f1bcc5cc" standard verify_py38 copy_python_gdb ensurepip
 else
-  install_package "Python-3.8.8" "https://www.python.org/ftp/python/3.8.8/Python-3.8.8.tgz#76c0763f048e4f9b861d24da76b7dd5c7a3ba7ec086f40caedeea359263276f7" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip
+  install_package "Python-3.8.8" "https://www.python.org/ftp/python/3.8.8/Python-3.8.8.tgz#76c0763f048e4f9b861d24da76b7dd5c7a3ba7ec086f40caedeea359263276f7" standard verify_py38 copy_python_gdb ensurepip
 fi

--- a/ubuntu/standard/5.0/tools/runtime_configs/python/3.9.2
+++ b/ubuntu/standard/5.0/tools/runtime_configs/python/3.9.2
@@ -11,9 +11,9 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.1i" "https://www.openssl.org/source/old/1.1.1/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-    install_package "Python-3.9.2" "https://www.python.org/ftp/python/3.9.2/Python-3.9.2.tar.xz#3c2034c54f811448f516668dce09d24008a0716c3a794dd8639b5388cbde247d" ldflags_dirs standard verify_py39 copy_python_gdb ensurepip
+    install_package "Python-3.9.2" "https://www.python.org/ftp/python/3.9.2/Python-3.9.2.tar.xz#3c2034c54f811448f516668dce09d24008a0716c3a794dd8639b5388cbde247d" standard verify_py39 copy_python_gdb ensurepip
 else
-    install_package "Python-3.9.2" "https://www.python.org/ftp/python/3.9.2/Python-3.9.2.tgz#7899e8a6f7946748830d66739f2d8f2b30214dad956e56b9ba216b3de5581519" ldflags_dirs standard verify_py39 copy_python_gdb ensurepip
+    install_package "Python-3.9.2" "https://www.python.org/ftp/python/3.9.2/Python-3.9.2.tgz#7899e8a6f7946748830d66739f2d8f2b30214dad956e56b9ba216b3de5581519" standard verify_py39 copy_python_gdb ensurepip
 fi
 
 

--- a/unsupported_images/al2/x86_64/standard/1.0/tools/runtime_configs/python/3.7.6
+++ b/unsupported_images/al2/x86_64/standard/1.0/tools/runtime_configs/python/3.7.6
@@ -11,9 +11,9 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.7.6" "https://www.python.org/ftp/python/3.7.6/Python-3.7.6.tar.xz#55a2cce72049f0794e9a11a84862e9039af9183603b78bc60d89539f82cf533f" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.7.6" "https://www.python.org/ftp/python/3.7.6/Python-3.7.6.tar.xz#55a2cce72049f0794e9a11a84862e9039af9183603b78bc60d89539f82cf533f" standard verify_py37 copy_python_gdb ensurepip
 else
-  install_package "Python-3.7.6" "https://www.python.org/ftp/python/3.7.6/Python-3.7.6.tgz#aeee681c235ad336af116f08ab6563361a0c81c537072c1b309d6e4050aa2114" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.7.6" "https://www.python.org/ftp/python/3.7.6/Python-3.7.6.tgz#aeee681c235ad336af116f08ab6563361a0c81c537072c1b309d6e4050aa2114" standard verify_py37 copy_python_gdb ensurepip
 fi
 
 

--- a/unsupported_images/al2/x86_64/standard/1.0/tools/runtime_configs/python/3.8.1
+++ b/unsupported_images/al2/x86_64/standard/1.0/tools/runtime_configs/python/3.8.1
@@ -11,9 +11,9 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.8.1" "https://www.python.org/ftp/python/3.8.1/Python-3.8.1.tar.xz#75894117f6db7051c1b34f37410168844bbb357c139a8a10a352e9bf8be594e8" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip
+  install_package "Python-3.8.1" "https://www.python.org/ftp/python/3.8.1/Python-3.8.1.tar.xz#75894117f6db7051c1b34f37410168844bbb357c139a8a10a352e9bf8be594e8" standard verify_py38 copy_python_gdb ensurepip
 else
-  install_package "Python-3.8.1" "https://www.python.org/ftp/python/3.8.1/Python-3.8.1.tgz#c7cfa39a43b994621b245e029769e9126caa2a93571cee2e743b213cceac35fb" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip
+  install_package "Python-3.8.1" "https://www.python.org/ftp/python/3.8.1/Python-3.8.1.tgz#c7cfa39a43b994621b245e029769e9126caa2a93571cee2e743b213cceac35fb" standard verify_py38 copy_python_gdb ensurepip
 fi
 
 

--- a/unsupported_images/ubuntu/standard/1.0/tools/runtime_configs/python/3.7.6
+++ b/unsupported_images/ubuntu/standard/1.0/tools/runtime_configs/python/3.7.6
@@ -11,9 +11,9 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.7.6" "https://www.python.org/ftp/python/3.7.6/Python-3.7.6.tar.xz#55a2cce72049f0794e9a11a84862e9039af9183603b78bc60d89539f82cf533f" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.7.6" "https://www.python.org/ftp/python/3.7.6/Python-3.7.6.tar.xz#55a2cce72049f0794e9a11a84862e9039af9183603b78bc60d89539f82cf533f" standard verify_py37 copy_python_gdb ensurepip
 else
-  install_package "Python-3.7.6" "https://www.python.org/ftp/python/3.7.6/Python-3.7.6.tgz#aeee681c235ad336af116f08ab6563361a0c81c537072c1b309d6e4050aa2114" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.7.6" "https://www.python.org/ftp/python/3.7.6/Python-3.7.6.tgz#aeee681c235ad336af116f08ab6563361a0c81c537072c1b309d6e4050aa2114" standard verify_py37 copy_python_gdb ensurepip
 fi
 
 

--- a/unsupported_images/ubuntu/standard/1.0/tools/runtime_configs/python/3.8.1
+++ b/unsupported_images/ubuntu/standard/1.0/tools/runtime_configs/python/3.8.1
@@ -11,9 +11,9 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.8.1" "https://www.python.org/ftp/python/3.8.1/Python-3.8.1.tar.xz#75894117f6db7051c1b34f37410168844bbb357c139a8a10a352e9bf8be594e8" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip
+  install_package "Python-3.8.1" "https://www.python.org/ftp/python/3.8.1/Python-3.8.1.tar.xz#75894117f6db7051c1b34f37410168844bbb357c139a8a10a352e9bf8be594e8" standard verify_py38 copy_python_gdb ensurepip
 else
-  install_package "Python-3.8.1" "https://www.python.org/ftp/python/3.8.1/Python-3.8.1.tgz#c7cfa39a43b994621b245e029769e9126caa2a93571cee2e743b213cceac35fb" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip
+  install_package "Python-3.8.1" "https://www.python.org/ftp/python/3.8.1/Python-3.8.1.tgz#c7cfa39a43b994621b245e029769e9126caa2a93571cee2e743b213cceac35fb" standard verify_py38 copy_python_gdb ensurepip
 fi
 
 

--- a/unsupported_images/ubuntu/standard/2.0/tools/runtime_configs/python/3.7.6
+++ b/unsupported_images/ubuntu/standard/2.0/tools/runtime_configs/python/3.7.6
@@ -11,9 +11,9 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.7.6" "https://www.python.org/ftp/python/3.7.6/Python-3.7.6.tar.xz#55a2cce72049f0794e9a11a84862e9039af9183603b78bc60d89539f82cf533f" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.7.6" "https://www.python.org/ftp/python/3.7.6/Python-3.7.6.tar.xz#55a2cce72049f0794e9a11a84862e9039af9183603b78bc60d89539f82cf533f" standard verify_py37 copy_python_gdb ensurepip
 else
-  install_package "Python-3.7.6" "https://www.python.org/ftp/python/3.7.6/Python-3.7.6.tgz#aeee681c235ad336af116f08ab6563361a0c81c537072c1b309d6e4050aa2114" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.7.6" "https://www.python.org/ftp/python/3.7.6/Python-3.7.6.tgz#aeee681c235ad336af116f08ab6563361a0c81c537072c1b309d6e4050aa2114" standard verify_py37 copy_python_gdb ensurepip
 fi
 
 

--- a/unsupported_images/ubuntu/standard/2.0/tools/runtime_configs/python/3.8.1
+++ b/unsupported_images/ubuntu/standard/2.0/tools/runtime_configs/python/3.8.1
@@ -11,9 +11,9 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.8.1" "https://www.python.org/ftp/python/3.8.1/Python-3.8.1.tar.xz#75894117f6db7051c1b34f37410168844bbb357c139a8a10a352e9bf8be594e8" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip
+  install_package "Python-3.8.1" "https://www.python.org/ftp/python/3.8.1/Python-3.8.1.tar.xz#75894117f6db7051c1b34f37410168844bbb357c139a8a10a352e9bf8be594e8" standard verify_py38 copy_python_gdb ensurepip
 else
-  install_package "Python-3.8.1" "https://www.python.org/ftp/python/3.8.1/Python-3.8.1.tgz#c7cfa39a43b994621b245e029769e9126caa2a93571cee2e743b213cceac35fb" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip
+  install_package "Python-3.8.1" "https://www.python.org/ftp/python/3.8.1/Python-3.8.1.tgz#c7cfa39a43b994621b245e029769e9126caa2a93571cee2e743b213cceac35fb" standard verify_py38 copy_python_gdb ensurepip
 fi
 
 


### PR DESCRIPTION
*Issue #, if available:* #460

*Description of changes:*

[pyenv 2.0.0](https://github.com/pyenv/pyenv/blob/master/CHANGELOG.md#release-200) removed ldflags_dirs as it "is not needed for Python and causes failures". The python runtime config files use the outdated calls. This pull request removes all references to `ldflags_dirs`. Now it is possible to build the images again.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
