### PR TITLE
standard:5.0 Golang version 1.16 support and bump to 1.15.12

### DIFF
--- a/ubuntu/standard/5.0/Dockerfile
+++ b/ubuntu/standard/5.0/Dockerfile
@@ -282,9 +282,11 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin -
 #****************      END PHP     ****************************************************
 
 #****************     GOLANG     ****************************************************
-ENV GOLANG_15_VERSION="1.15.6"
+ENV GOLANG_15_VERSION="1.15.12"
+ENV GOLANG_16_VERSION="1.16.4"
 
-RUN goenv install $GOLANG_15_VERSION; rm -rf /tmp/*; \
+RUN goenv install $GOLANG_15_VERSION;\
+    goenv install $GOLANG_16_VERSION; rm -rf /tmp/*; \
     goenv global  $GOLANG_15_VERSION
 
 RUN go get -u github.com/golang/dep/cmd/dep

--- a/ubuntu/standard/5.0/runtimes.yml
+++ b/ubuntu/standard/5.0/runtimes.yml
@@ -47,6 +47,10 @@ runtimes:
         commands:
           - echo "Installing Go version 1.15 ..."
           - goenv global  $GOLANG_15_VERSION
+      1.16:
+        commands:
+          - echo "Installing Go version 1.16 ..."
+          - goenv global  $GOLANG_16_VERSION          
   python:
     versions:
       3.7:


### PR DESCRIPTION
*Issue #, if available:* closes #425

*Description of changes:*
`aws/codebuild/standard:5.0` image changes
- Add support for `golang: 1.16`
- Bump go 1.15 to latest version `1.15.12`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
