### PR TITLE
Enable sodium for PHP since it should be bundled by default as of PHP 7.2.0

### DIFF
--- a/ubuntu/standard/5.0/Dockerfile
+++ b/ubuntu/standard/5.0/Dockerfile
@@ -41,7 +41,7 @@ RUN set -ex \
           libglib2.0-dev libhttp-date-perl libio-pty-perl libjpeg-dev \
           libkrb5-dev liblzma-dev libmagickcore-dev libmagickwand-dev \
           libmysqlclient-dev libncurses5-dev libncursesw5-dev libonig-dev \
-          libpq-dev libreadline-dev libserf-1-1 libsqlite3-dev libssl-dev \
+          libpq-dev libreadline-dev libserf-1-1 libsodium-dev libsqlite3-dev libssl-dev \
           libsvn1 libsvn-perl libtcl8.6 libtidy-dev libtimedate-perl \
           libtool libwebp-dev libxml2-dev libxml2-utils libxslt1-dev \
           libyaml-dev libyaml-perl llvm locales make mlocate \

--- a/ubuntu/standard/5.0/tools/runtime_configs/php/7.3.25
+++ b/ubuntu/standard/5.0/tools/runtime_configs/php/7.3.25
@@ -2,6 +2,7 @@ configure_option "--with-curl"
 configure_option "--with-libedit"
 configure_option "--with-password-argon2"
 configure_option "--with-pdo-pgsql"
+configure_option "--with-sodium"
 
 PHP_BUILD_EXTRA_MAKE_ARGUMENTS="-j4"
 

--- a/ubuntu/standard/5.0/tools/runtime_configs/php/7.4.13
+++ b/ubuntu/standard/5.0/tools/runtime_configs/php/7.4.13
@@ -2,6 +2,7 @@ configure_option "--with-curl"
 configure_option "--with-password-argon2"
 configure_option "--with-pdo-pgsql"
 configure_option "--with-libedit"
+configure_option "--with-sodium"
 
 PHP_BUILD_EXTRA_MAKE_ARGUMENTS="-j4"
 

--- a/ubuntu/standard/5.0/tools/runtime_configs/php/8.0.0
+++ b/ubuntu/standard/5.0/tools/runtime_configs/php/8.0.0
@@ -2,6 +2,7 @@ configure_option "--with-curl"
 configure_option "--with-password-argon2"
 configure_option "--with-pdo-pgsql"
 configure_option "--with-libedit"
+configure_option "--with-sodium"
 
 PHP_BUILD_EXTRA_MAKE_ARGUMENTS="-j4"
 


### PR DESCRIPTION
*Issue #, if available:*

Both Debian 10 and latest Mac OS X have PHP with sodium extension compiled in - https://www.php.net/manual/en/sodium.installation.php

When you run composer update locally it sees that the extension is available and builds the dependencies around it. However, when you deploy with Codebuild the extension is no longer available and it is hard to install it since during deployment since there is no package available for it. I believe the package maintainers assume it is already bundled in so no package is required.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
