### PR TITLE
chore: bump node 14.x to latest 14.17.2

### DIFF
--- a/ubuntu/standard/5.0/Dockerfile
+++ b/ubuntu/standard/5.0/Dockerfile
@@ -202,7 +202,7 @@ RUN set -ex \
 #****************      NODEJS     ****************************************************
 
 ENV NODE_12_VERSION="12.20.1"
-ENV NODE_14_VERSION="14.15.4"
+ENV NODE_14_VERSION="14.17.2"
 
 RUN     n $NODE_14_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \
      && n $NODE_12_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \


### PR DESCRIPTION
*Issue #, if available:*
Blog post on July 2021 Security Releases: nodejs.org/en/blog/vulnerability/july-2021-security-releases

*Description of changes:*
bump node 14.x to latest 14.17.2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
