### PR TITLE
Ubuntu Standard: Add Go 1.17 support

### DIFF
--- a/ubuntu/standard/5.0/Dockerfile
+++ b/ubuntu/standard/5.0/Dockerfile
@@ -285,7 +285,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin -
 #****************     GOLANG     ****************************************************
 ENV GOLANG_15_VERSION="1.15.12"
 ENV GOLANG_16_VERSION="1.16.4"
-ENV GOLANG_17_VERSION="1.17"
+ENV GOLANG_17_VERSION="1.17.1"
 
 RUN goenv install $GOLANG_15_VERSION;\
     goenv install $GOLANG_16_VERSION;\

--- a/ubuntu/standard/5.0/Dockerfile
+++ b/ubuntu/standard/5.0/Dockerfile
@@ -285,9 +285,11 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin -
 #****************     GOLANG     ****************************************************
 ENV GOLANG_15_VERSION="1.15.12"
 ENV GOLANG_16_VERSION="1.16.4"
+ENV GOLANG_17_VERSION="1.17"
 
 RUN goenv install $GOLANG_15_VERSION;\
-    goenv install $GOLANG_16_VERSION; rm -rf /tmp/*; \
+    goenv install $GOLANG_16_VERSION;\
+    goenv install $GOLANG_17_VERSION; rm -rf /tmp/*; \
     goenv global  $GOLANG_15_VERSION
 
 RUN go get -u github.com/golang/dep/cmd/dep

--- a/ubuntu/standard/5.0/runtimes.yml
+++ b/ubuntu/standard/5.0/runtimes.yml
@@ -50,7 +50,11 @@ runtimes:
       1.16:
         commands:
           - echo "Installing Go version 1.16 ..."
-          - goenv global  $GOLANG_16_VERSION          
+          - goenv global  $GOLANG_16_VERSION
+      1.17:
+        commands:
+          - echo "Installing Go version 1.17 ..."
+          - goenv global  $GOLANG_17_VERSION
   python:
     versions:
       3.7:


### PR DESCRIPTION
*Description of changes:*

This patch adds Go 1.17 support to Ubuntu Standard 5.0.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
