### PR TITLE
Correct Docker version in log string

### DIFF
--- a/al2/x86_64/standard/3.0/runtimes.yml
+++ b/al2/x86_64/standard/3.0/runtimes.yml
@@ -115,7 +115,7 @@ runtimes:
     versions:
       18:
         commands:
-          - echo "Using Docker 19"
+          - echo "Using Docker 18"
       19:
         commands:
           - echo "Using Docker 19"


### PR DESCRIPTION
*Issue #, if available:*
#479 

*Description of changes:*
Correct typo in runtimes.yml that incorrectly reports Docker 19 in logs when Docker 18 is specified

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
