### PR TITLE
Remove unnecessary and redundant code in runtimes.yml for al2/x86_64 ver3.0.

### DIFF
--- a/al2/x86_64/standard/3.0/runtimes.yml
+++ b/al2/x86_64/standard/3.0/runtimes.yml
@@ -113,9 +113,6 @@ runtimes:
           - n $NODE_12_VERSION
   docker:
     versions:
-      18:
-        commands:
-          - echo "Using Docker 19"
       19:
         commands:
           - echo "Using Docker 19"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

It seems that ver19 is used even if the Docker version is specified as 18 in runtime-versions.
It appears to be usable in the current code, but I thought it should be removed as it may be misleading.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
