### PR TITLE
Add missing `yum clean all` to JAVA install block in AL2 (ARM) (Fixes PowerShell Install)

### DIFF
--- a/al2/aarch64/standard/2.0/Dockerfile
+++ b/al2/aarch64/standard/2.0/Dockerfile
@@ -203,6 +203,7 @@ ENV PATH "/usr/local/bin/sbt/bin:$PATH"
 RUN sbt version
 # Cleanup
 RUN rm -fr /tmp/* /var/tmp/* \
+    && yum clean all
 #****************     END JAVA     ****************************************************
 
 


### PR DESCRIPTION
*Description of changes:*

This fixes an issue with the **PowerShell Core** installation, as an empty continuation line at the end of the **JAVA** install block was messing with `ENV POWERSHELL_VERSION` being set.

Adds the `&& yum clean all` present in the AL2 x86_64 image.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
