### PR TITLE
Update Node 14 to fix security vulnerabilities

### DIFF
--- a/ubuntu/standard/5.0/Dockerfile
+++ b/ubuntu/standard/5.0/Dockerfile
@@ -202,7 +202,7 @@ RUN set -ex \
 #****************      NODEJS     ****************************************************
 
 ENV NODE_12_VERSION="12.22.2"
-ENV NODE_14_VERSION="14.17.2"
+ENV NODE_14_VERSION="14.18.1"
 
 RUN     n $NODE_14_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \
      && n $NODE_12_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \


### PR DESCRIPTION
*Description of changes:*
- 2021-07-29 https://nodejs.org/en/blog/release/v14.17.4/ fixed CVE-2021-22930 (High)
- 2021-08-11 https://nodejs.org/en/blog/release/v14.17.5/ fixed CVE-2021-3672/CVE-2021-22931 (High), CVE-2021-22940 (High), CVE-2021-22939 (Low)
- 2021-08-31 https://nodejs.org/en/blog/release/v14.17.6/ fixed CVE-2021-37701, CVE-2021-37712, CVE-2021-37713, CVE-2021-39134, CVE-2021-39135
- 2021-09-28 https://nodejs.org/en/blog/release/v14.18.0/ was not a security update
- 2021-10-12 https://nodejs.org/en/blog/release/v14.18.1/ fixed CVE-2021-22959 (Medium), CVE-2021-22960 (Medium)

As this image is actively maintained (https://github.com/aws/aws-codebuild-docker-images#image-maintenance), can we expect the Node version to be bumped by AWS whenever there is a new release within the same major version?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
