### PR TITLE
Adding amazoncorretto 17 runtime for java

### DIFF
--- a/al2/x86_64/standard/3.0/Dockerfile
+++ b/al2/x86_64/standard/3.0/Dockerfile
@@ -246,7 +246,7 @@ RUN set -x \
     && rm -r "$GNUPGHOME" corretto.key \
     && curl -fL -o /etc/yum.repos.d/corretto.repo https://yum.corretto.aws/corretto.repo \
     && grep -q '^gpgcheck=1' /etc/yum.repos.d/corretto.repo \
-    && yum install -y java-17-amazon-corretto-devel-17.0.0.35-1 \
+    && yum install -y java-17-amazon-corretto-devel \
     && (find /usr/lib/jvm/java-17-amazon-corretto -name src.zip -delete || true) \
     && yum install -y fontconfig \
     && for tool_path in $JAVA_HOME/bin/*; do \

--- a/al2/x86_64/standard/3.0/Dockerfile
+++ b/al2/x86_64/standard/3.0/Dockerfile
@@ -166,7 +166,10 @@ FROM tools AS runtimes_1
 #****************      JAVA     ****************************************************
 COPY tools/android-accept-licenses.sh /opt/tools/android-accept-licenses.sh
 
-ENV JAVA_11_HOME="/usr/lib/jvm/java-11-amazon-corretto.x86_64" \
+ENV JAVA_17_HOME="/usr/lib/jvm/java-17-amazon-corretto" \
+    JDK_17_HOME="/usr/lib/jvm/java-17-amazon-corretto" \
+    JRE_17_HOME="/usr/lib/jvm/java-17-amazon-corretto" \
+    JAVA_11_HOME="/usr/lib/jvm/java-11-amazon-corretto.x86_64" \
     JDK_11_HOME="/usr/lib/jvm/java-11-amazon-corretto.x86_64" \
     JRE_11_HOME="/usr/lib/jvm/java-11-amazon-corretto.x86_64" \
     JAVA_8_HOME="/usr/lib/jvm/java-1.8.0-amazon-corretto.x86_64" \
@@ -226,6 +229,26 @@ RUN set -x \
     # Install Amazon Corretto 11
     # Note: We will use update-alternatives to make sure JDK11 has higher priority for all the tools
     && yum install -y -q java-11-amazon-corretto \
+    && for tool_path in $JAVA_HOME/bin/*; do \
+          tool=`basename $tool_path`; \
+          update-alternatives --install /usr/bin/$tool $tool $tool_path 10000; \
+          update-alternatives --set $tool $tool_path; \
+        done
+
+RUN set -x \
+    # Install Amazon Corretto 17
+    # Note: We will use update-alternatives to make sure JDK11 has higher priority for all the tools
+    && export GNUPGHOME="$(mktemp -d)" \
+    && curl -fL -o corretto.key https://yum.corretto.aws/corretto.key \
+    && gpg --batch --import corretto.key \
+    && gpg --batch --export --armor '6DC3636DAE534049C8B94623A122542AB04F24E3' > corretto.key \
+    && rpm --import corretto.key \
+    && rm -r "$GNUPGHOME" corretto.key \
+    && curl -fL -o /etc/yum.repos.d/corretto.repo https://yum.corretto.aws/corretto.repo \
+    && grep -q '^gpgcheck=1' /etc/yum.repos.d/corretto.repo \
+    && yum install -y java-17-amazon-corretto-devel-17.0.0.35-1 \
+    && (find /usr/lib/jvm/java-17-amazon-corretto -name src.zip -delete || true) \
+    && yum install -y fontconfig \
     && for tool_path in $JAVA_HOME/bin/*; do \
           tool=`basename $tool_path`; \
           update-alternatives --install /usr/bin/$tool $tool $tool_path 10000; \

--- a/al2/x86_64/standard/3.0/runtimes.yml
+++ b/al2/x86_64/standard/3.0/runtimes.yml
@@ -15,6 +15,25 @@ runtimes:
           - echo "Installing Android version 29 ..."
   java:
     versions:
+      corretto17:
+        commands:
+          - echo "Installing corretto(OpenJDK) version 17 ..."
+
+          - export JAVA_HOME="$JAVA_17_HOME"
+
+          - export JRE_HOME="$JRE_17_HOME"
+
+          - export JDK_HOME="$JDK_17_HOME"
+
+          - |-
+            for tool_path in "$JAVA_HOME"/bin/*;
+             do tool=`basename "$tool_path"`;
+              if [ $tool != 'java-rmi.cgi' ];
+              then
+               rm -f /usr/bin/$tool /var/lib/alternatives/$tool \
+                && update-alternatives --install /usr/bin/$tool $tool $tool_path 20000;
+              fi;
+            done
       corretto11:
         commands:
           - echo "Installing corretto(OpenJDK) version 11 ..."

--- a/ubuntu/standard/5.0/Dockerfile
+++ b/ubuntu/standard/5.0/Dockerfile
@@ -313,6 +313,9 @@ RUN go get -u github.com/golang/dep/cmd/dep
 FROM runtimes AS runtimes_n_corretto
 
 #****************      JAVA     ****************************************************
+ENV JAVA_17_HOME="/usr/lib/jvm/java-17-amazon-corretto"
+ENV JDK_17_HOME="/usr/lib/jvm/java-17-amazon-corretto"
+ENV JRE_17_HOME="/usr/lib/jvm/java-17-amazon-corretto"
 ENV JAVA_11_HOME="/usr/lib/jvm/java-11-amazon-corretto"
 ENV JDK_11_HOME="/usr/lib/jvm/java-11-amazon-corretto"
 ENV JRE_11_HOME="/usr/lib/jvm/java-11-amazon-corretto"
@@ -365,6 +368,16 @@ RUN set -ex \
           tool=`basename $tool_path`; \
           update-alternatives --install /usr/bin/$tool $tool $tool_path 10000; \
           update-alternatives --set $tool $tool_path; \
+        done
+
+RUN set -ex \
+    # Install Corretto 17
+    # Note: We will use update-alternatives to make sure JDK11 has higher priority for all the tools
+    && apt-get install -y -qq java-17-amazon-corretto-jdk \
+    && for tool_path in $JAVA_HOME/bin/*; do \
+          tool=`basename $tool_path`; \
+          update-alternatives --install /usr/bin/$tool $tool $tool_path 10000; \
+          update-alternatives --set $tool $tool_path; \
         done \
      && rm $JAVA_HOME/lib/security/cacerts && ln -s /etc/ssl/certs/java/cacerts $JAVA_HOME/lib/security/cacerts \
     # Install Ant
@@ -372,7 +385,7 @@ RUN set -ex \
     && echo "$ANT_DOWNLOAD_SHA512 /var/tmp/apache-ant-$ANT_VERSION-bin.tar.gz" | sha512sum -c - \
     && tar -xzf /var/tmp/apache-ant-$ANT_VERSION-bin.tar.gz -C /opt \
     && rm /var/tmp/apache-ant-$ANT_VERSION-bin.tar.gz \
-    && update-alternatives --install /usr/bin/ant ant /opt/apache-ant-$ANT_VERSION/bin/ant 10000 
+    && update-alternatives --install /usr/bin/ant ant /opt/apache-ant-$ANT_VERSION/bin/ant 10000
 
 RUN set -ex \
     # Install Maven

--- a/ubuntu/standard/5.0/runtimes.yml
+++ b/ubuntu/standard/5.0/runtimes.yml
@@ -41,6 +41,25 @@ runtimes:
                 && update-alternatives --set "$tool" "$tool_path";
               fi;
             done
+      corretto17:
+        commands:
+          - echo "Installing Java version 17 ..."
+
+          - export JAVA_HOME="$JAVA_17_HOME"
+
+          - export JRE_HOME="$JRE_17_HOME"
+
+          - export JDK_HOME="$JDK_17_HOME"
+
+          - |-
+            for tool_path in "$JAVA_HOME"/bin/*;
+             do tool=`basename "$tool_path"`;
+              if [ $tool != 'java-rmi.cgi' ];
+              then
+               update-alternatives --list "$tool" | grep -q "$tool_path" \
+                && update-alternatives --set "$tool" "$tool_path";
+              fi;
+            done
   golang:
     versions:
       1.15:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding amazon corretto 17 to the runtimes.


Tested with

```bash
docker run -it -v /var/run/docker.sock:/var/run/docker.sock -e "IMAGE_NAME=aws/codebuild/standard:5.0.1" -e "ARTIFACTS=/home/john/artifacts/" -e "SOURCE=/home/john/GIT/pycharm/aws-codebuild-docker-images/ubuntu/standard/5.0" -e "BUILDSPEC=/home/john/GIT/pycharm/aws-codebuild-docker-images/ubuntu/standard/5.0/test.yaml" -e "INITIATOR=john" public.ecr.aws/codebuild/local-builds:latest
```

And file for test

```yaml
version: 0.2

phases:
  install:
    runtime-versions:
      java: corretto17
  build:
    commands:
      - java -version

```

And running mvn with sample application

```yaml
version: 0.2

phases:
  install:
    runtime-versions:
      java: corretto17
  build:
    commands:
      - java -version
      - mvn clean package
```

with both al2 and ubuntu, all pass as per my build tests.