### PR TITLE
Ubuntu Standard 5 -  Add .NET 6

### DIFF
--- a/ubuntu/standard/5.0/Dockerfile
+++ b/ubuntu/standard/5.0/Dockerfile
@@ -161,6 +161,7 @@ FROM tools AS runtimes
 
 ENV DOTNET_31_SDK_VERSION="3.1.404"
 ENV DOTNET_5_SDK_VERSION="5.0.202"
+ENV DOTNET_6_SDK_VERSION="6.0.100"
 ENV DOTNET_ROOT="/root/.dotnet"
 
 # Add .NET Core 3.1 Global Tools install folder to PATH
@@ -170,6 +171,11 @@ RUN  /usr/local/bin/dotnet-install.sh -v $DOTNET_31_SDK_VERSION \
 
 # Add .NET Core 5 Global Tools install folder to PATH
 RUN  /usr/local/bin/dotnet-install.sh -v $DOTNET_5_SDK_VERSION \
+     && dotnet --list-sdks \
+     && rm -rf /tmp/*
+
+# Add .NET Core 6 Global Tools install folder to PATH
+RUN  /usr/local/bin/dotnet-install.sh -v $DOTNET_6_SDK_VERSION \
      && dotnet --list-sdks \
      && rm -rf /tmp/*
 

--- a/ubuntu/standard/5.0/runtimes.yml
+++ b/ubuntu/standard/5.0/runtimes.yml
@@ -109,3 +109,7 @@ runtimes:
         commands:
           - echo "Installing .NET version 5.0 ..."
           - test -f "global.json" && echo "Using provided global.json" || dotnet new globaljson --sdk-version $DOTNET_5_SDK_VERSION
+      6.0:
+        commands:
+          - echo "Installing .NET version 6.0 ..."
+          - test -f "global.json" && echo "Using provided global.json" || dotnet new globaljson --sdk-version $DOTNET_6_SDK_VERSION


### PR DESCRIPTION
*Issue #, if available:*

Ubuntu Standard 5 -  Add .NET 6

```
root@0cfbe99c76b7:/# dotnet --info
.NET SDK (reflecting any global.json):
 Version:   6.0.100
 Commit:    9e8b04bbff

Runtime Environment:
 OS Name:     ubuntu
 OS Version:  20.04
 OS Platform: Linux
 RID:         ubuntu.20.04-x64
 Base Path:   /root/.dotnet/sdk/6.0.100/

Host (useful for support):
  Version: 6.0.0
  Commit:  4822e3c3aa

.NET SDKs installed:
  3.1.404 [/root/.dotnet/sdk]
  5.0.202 [/root/.dotnet/sdk]
  6.0.100 [/root/.dotnet/sdk]

.NET runtimes installed:
  Microsoft.AspNetCore.App 3.1.10 [/root/.dotnet/shared/Microsoft.AspNetCore.App]
  Microsoft.AspNetCore.App 5.0.5 [/root/.dotnet/shared/Microsoft.AspNetCore.App]
  Microsoft.AspNetCore.App 6.0.0 [/root/.dotnet/shared/Microsoft.AspNetCore.App]
  Microsoft.NETCore.App 3.1.10 [/root/.dotnet/shared/Microsoft.NETCore.App]
  Microsoft.NETCore.App 5.0.5 [/root/.dotnet/shared/Microsoft.NETCore.App]
  Microsoft.NETCore.App 6.0.0 [/root/.dotnet/shared/Microsoft.NETCore.App]

To install additional .NET runtimes or SDKs:
  https://aka.ms/dotnet-download
root@0cfbe99c76b7:/#
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
