### PR TITLE
update NodeJS in AL2 images

### DIFF
--- a/al2/x86_64/standard/2.0/Dockerfile
+++ b/al2/x86_64/standard/2.0/Dockerfile
@@ -305,8 +305,14 @@ RUN set -ex \
 #****************      NODEJS     ****************************************************
 
 ENV NODE_10_VERSION="10.19.0"
+ENV NODE_12_VERSION="12.22.7"
+ENV NODE_14_VERSION="14.18.2"
+ENV NODE_16_VERSION="16.13.1"
 
 RUN  n $NODE_10_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \
+     n $NODE_12_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \
+     n $NODE_14_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \
+     n $NODE_16_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \
      && curl -sSL https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo \
      && rpm --import https://dl.yarnpkg.com/rpm/pubkey.gpg \
      && yum install -yq yarn \

--- a/al2/x86_64/standard/2.0/runtimes.yml
+++ b/al2/x86_64/standard/2.0/runtimes.yml
@@ -87,6 +87,14 @@ runtimes:
           - rbenv global $RUBY_26_VERSION
   nodejs:
     versions:
+      16:
+        commands:
+          - echo "Installing Node.js version 16 ..."
+          - n $NODE_16_VERSION
+      14:
+        commands:
+          - echo "Installing Node.js version 14 ..."
+          - n $NODE_14_VERSION
       12:
         commands:
           - echo "Installing Node.js version 12 ..."

--- a/al2/x86_64/standard/3.0/Dockerfile
+++ b/al2/x86_64/standard/3.0/Dockerfile
@@ -300,14 +300,14 @@ RUN set -ex \
 #****************      NODEJS     ****************************************************
 
 ENV NODE_10_VERSION="10.24.1"
-ENV NODE_12_VERSION="12.22.7"
-ENV NODE_14_VERSION="14.18.2"
-ENV NODE_16_VERSION="16.13.1"
+ENV NODE_12_VERSION="12.22.9"
+ENV NODE_14_VERSION="14.18.3"
+ENV NODE_16_VERSION="16.13.2"
 
 RUN  n $NODE_10_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \
-     n $NODE_12_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \
-     n $NODE_14_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \
-     n $NODE_16_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \
+     && n $NODE_12_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \
+     && n $NODE_14_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \
+     && n $NODE_16_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \
      && curl -sSL https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo \
      && rpm --import https://dl.yarnpkg.com/rpm/pubkey.gpg \
      && yum install -yq yarn \

--- a/al2/x86_64/standard/3.0/Dockerfile
+++ b/al2/x86_64/standard/3.0/Dockerfile
@@ -300,8 +300,14 @@ RUN set -ex \
 #****************      NODEJS     ****************************************************
 
 ENV NODE_10_VERSION="10.24.1"
+ENV NODE_12_VERSION="12.22.7"
+ENV NODE_14_VERSION="14.18.2"
+ENV NODE_16_VERSION="16.13.1"
 
 RUN  n $NODE_10_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \
+     n $NODE_12_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \
+     n $NODE_14_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \
+     n $NODE_16_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \
      && curl -sSL https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo \
      && rpm --import https://dl.yarnpkg.com/rpm/pubkey.gpg \
      && yum install -yq yarn \

--- a/al2/x86_64/standard/3.0/runtimes.yml
+++ b/al2/x86_64/standard/3.0/runtimes.yml
@@ -111,6 +111,14 @@ runtimes:
         commands:
           - echo "Installing Node.js version 12 ..."
           - n $NODE_12_VERSION
+      14:
+        commands:
+          - echo "Installing Node.js version 14 ..."
+          - n $NODE_14_VERSION
+      16:
+        commands:
+          - echo "Installing Node.js version 16 ..."
+          - n $NODE_16_VERSION
   docker:
     versions:
       18:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

NodeJS in AL2 images seems to be not in line with the runtime versions listed in the AWS Docs: <https://docs.aws.amazon.com/codebuild/latest/userguide/runtime-versions.html>

With this PR, I'm adding NodeJS 12, 14 (and 16, since it's LTS now) to AL2 2.0 and 3.0 images.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
