### PR TITLE
fix echo message when runtime is docker18

### DIFF
--- a/al2/x86_64/standard/3.0/runtimes.yml
+++ b/al2/x86_64/standard/3.0/runtimes.yml
@@ -115,7 +115,7 @@ runtimes:
     versions:
       18:
         commands:
-          - echo "Using Docker 19"
+          - echo "Using Docker 18"
       19:
         commands:
           - echo "Using Docker 19"

--- a/ubuntu/standard/4.0/runtimes.yml
+++ b/ubuntu/standard/4.0/runtimes.yml
@@ -116,7 +116,7 @@ runtimes:
     versions:
       18:
         commands:
-          - echo "Using Docker 19"
+          - echo "Using Docker 18"
       19:
         commands:
           - echo "Using Docker 19"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
fix log when runtime is docker18

before
```
echo "Using Docker 19"
```

after
```
echo "Using Docker 18"
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
