### PR TITLE
Update fedora supplied libuv rpm version

### DIFF
--- a/al2/x86_64/standard/3.0/Dockerfile
+++ b/al2/x86_64/standard/3.0/Dockerfile
@@ -306,7 +306,7 @@ ENV NODE_10_VERSION="10.24.1"
 RUN  n $NODE_10_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \
      && curl -sSL https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo \
      && rpm --import https://dl.yarnpkg.com/rpm/pubkey.gpg \
-     && yum install -y https://download-ib01.fedoraproject.org/pub/epel/8/Modular/x86_64/Packages/l/libuv-1.43.0-2.module_el8+13774+f8c1f5a5.x86_64.rpm \
+     && yum install -y https://download-ib01.fedoraproject.org/pub/epel/8/Modular/x86_64/Packages/l/libuv-1.43.0-2.module_el8+13804+34326f90.x86_64.rpm \
      && yum install -y -q yarn \
      && yarn --version \
      && cd / && rm -rf $N_SRC_DIR && rm -rf /tmp/*


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Update version of libuv-1.43 to a slightly newer (and available) build 13804 from 13774.
Fedora seems to have updated this file fairly recently - 2022-05-03 19:38

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
