### PR TITLE
Re-enable libsodium for PHP in Ubuntu 5.0

### DIFF
--- a/ubuntu/standard/5.0/tools/runtime_configs/php/7.3.33
+++ b/ubuntu/standard/5.0/tools/runtime_configs/php/7.3.33
@@ -2,6 +2,7 @@ configure_option "--with-curl"
 configure_option "--with-libedit"
 configure_option "--with-password-argon2"
 configure_option "--with-pdo-pgsql"
+configure_option "--with-sodium"
 
 PHP_BUILD_EXTRA_MAKE_ARGUMENTS="-j4"
 

--- a/ubuntu/standard/5.0/tools/runtime_configs/php/7.4.29
+++ b/ubuntu/standard/5.0/tools/runtime_configs/php/7.4.29
@@ -2,6 +2,7 @@ configure_option "--with-curl"
 configure_option "--with-password-argon2"
 configure_option "--with-pdo-pgsql"
 configure_option "--with-libedit"
+configure_option "--with-sodium"
 
 PHP_BUILD_EXTRA_MAKE_ARGUMENTS="-j4"
 

--- a/ubuntu/standard/5.0/tools/runtime_configs/php/8.0.18
+++ b/ubuntu/standard/5.0/tools/runtime_configs/php/8.0.18
@@ -2,6 +2,7 @@ configure_option "--with-curl"
 configure_option "--with-password-argon2"
 configure_option "--with-pdo-pgsql"
 configure_option "--with-libedit"
+configure_option "--with-sodium"
 
 PHP_BUILD_EXTRA_MAKE_ARGUMENTS="-j4"
 


### PR DESCRIPTION
*Issue #538*

*Re-Enable libsodium for all PHP version in Ubuntu 5.0*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
