### PR TITLE
standard:5.0 Golang version 1.19 support

### DIFF
--- a/ubuntu/standard/6.0/Dockerfile
+++ b/ubuntu/standard/6.0/Dockerfile
@@ -227,9 +227,11 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin -
 #****************      END PHP     ****************************************************
 
 #****************     GOLANG     ****************************************************
-ENV GOLANG_18_VERSION="1.18.3"
+ENV GOLANG_18_VERSION="1.18.3" \
+    GOLANG_19_VERSION="1.19.0"
 
 RUN goenv install $GOLANG_18_VERSION && rm -rf /tmp/* && \
+    goenv install $GOLANG_19_VERSION && rm -rf /tmp/* && \
     goenv global  $GOLANG_18_VERSION && \
     go env -w GO111MODULE=auto
 

--- a/ubuntu/standard/6.0/runtimes.yml
+++ b/ubuntu/standard/6.0/runtimes.yml
@@ -28,6 +28,10 @@ runtimes:
         commands:
           - echo "Installing Go version 1.18 ..."
           - goenv global  $GOLANG_18_VERSION
+      1.19:
+        commands:
+          - echo "Installing Go version 1.19 ..."
+          - goenv global  $GOLANG_19_VERSION
   python:
     versions:
       3.10:


### PR DESCRIPTION
*Issue #, if available:*

Go version 1.19 has been released  (https://go.dev/blog/go1.19).

*Description of changes:*
aws/codebuild/standard:5.0 image changes

Add support for golang: 1.19

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
