### PR TITLE
Fix incompatible GitVersion version

### DIFF
--- a/al2/x86_64/standard/4.0/Dockerfile
+++ b/al2/x86_64/standard/4.0/Dockerfile
@@ -283,7 +283,7 @@ RUN   pyenv global  $PYTHON_39_VERSION
 RUN set -ex \
     && pip3 install --no-cache-dir --upgrade --force-reinstall "pip==$PYTHON_PIP_VERSION" \
     && pip3 install --no-cache-dir --upgrade "PyYAML==$PYYAML_VERSION" \
-    && pip3 install --no-cache-dir --upgrade 'setuptools==57.4.0' wheel aws-sam-cli awscli boto3 pipenv virtualenv --use-feature=2020-resolver    
+    && pip3 install --no-cache-dir --upgrade 'setuptools==57.4.0' wheel aws-sam-cli awscli boto3 pipenv virtualenv --use-feature=2020-resolver
 
 #**************** END PYTHON *****************************************************
 
@@ -303,7 +303,7 @@ ENV GOLANG_18_VERSION="1.18.3"
 ENV GOENV_DISABLE_GOPATH=1
 ENV GOPATH="/go"
 
-RUN goenv install $GOLANG_18_VERSION && rm -rf /tmp/* && \ 
+RUN goenv install $GOLANG_18_VERSION && rm -rf /tmp/* && \
     goenv global $GOLANG_18_VERSION && \
     go env -w GO111MODULE=auto
 
@@ -345,7 +345,7 @@ RUN set -ex \
 FROM runtimes_2 AS runtimes_3
 
 # Install GitVersion
-ENV GITVERSION_VERSION="5.3.5"
+ENV GITVERSION_VERSION="5.10.3"
 RUN set -ex \
     && dotnet tool install --global GitVersion.Tool --version $GITVERSION_VERSION \
     && ln -s ~/.dotnet/tools/dotnet-gitversion /usr/local/bin/gitversion


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Fix the error below, by upgrading gitversion to a version compatible with the installed dotnet runtime (6.0):

```
[Container] 2022/09/18 05:28:17 Running command gitversion
--
140 | It was not possible to find any compatible framework version
141 | The framework 'Microsoft.NETCore.App', version '3.1.0' (x64) was not found.
142 | - The following frameworks were found:
143 | 6.0.6 at [/root/.dotnet/shared/Microsoft.NETCore.App]
144 |  
145 | You can resolve the problem by installing the specified framework and/or SDK.

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
