### PR TITLE
added javac into al4:0

### DIFF
--- a/al2/x86_64/standard/4.0/Dockerfile
+++ b/al2/x86_64/standard/4.0/Dockerfile
@@ -39,7 +39,7 @@ RUN set -ex \
            perl-DBI perl-HTTP-Date perl-IO-Pty-Easy perl-TimeDate perl-YAML-LibYAML \
            postgresql-devel procps-ng python-configobj readline-devel rsync sgml-common \
            subversion-perl tar tcl tk vim wget which xfsprogs xmlto xorg-x11-server-Xvfb xz-devel \
-           amazon-ecr-credential-helper \
+           amazon-ecr-credential-helper java-17-amazon-corretto-devel \
     && rm /etc/yum.repos.d/mono-centos7-stable.repo
 
 RUN useradd codebuild-user


### PR DESCRIPTION
*Issue #567

https://github.com/aws/aws-codebuild-docker-images/issues/567

*Description of changes:*
Added `java-17-amazon-corretto-devel` which allows for javac to be used out of the box.

This seems like a common functionality which should be included by default.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
