### PR TITLE
Add Python 3.8.13 to CodeBuild 4.0

### DIFF
--- a/al2/x86_64/standard/4.0/Dockerfile
+++ b/al2/x86_64/standard/4.0/Dockerfile
@@ -274,10 +274,22 @@ RUN rbenv install $RUBY_31_VERSION && rm -rf /tmp/* && rbenv global $RUBY_31_VER
 #**************** END RUBY *****************************************************
 
 #**************** PYTHON *****************************************************
-#Python 3.9
-ENV PYTHON_39_VERSION="3.9.16"
 ENV PYTHON_PIP_VERSION=21.1.2
 ENV PYYAML_VERSION=5.4.1
+
+#Python 3.8
+ENV PYTHON_38_VERSION="3.8.13"
+
+COPY tools/runtime_configs/python/$PYTHON_38_VERSION /root/.pyenv/plugins/python-build/share/python-build/$PYTHON_38_VERSION
+RUN   env PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install $PYTHON_38_VERSION && rm -rf /tmp/*
+RUN   pyenv global  $PYTHON_38_VERSION
+RUN set -ex \
+    && pip3 install --no-cache-dir --upgrade --force-reinstall "pip==$PYTHON_PIP_VERSION" \
+    && pip3 install --no-cache-dir --upgrade "PyYAML==$PYYAML_VERSION" \
+    && pip3 install --no-cache-dir --upgrade 'setuptools==57.4.0' wheel aws-sam-cli awscli boto3 pipenv virtualenv --use-feature=2020-resolver
+
+#Python 3.9
+ENV PYTHON_39_VERSION="3.9.16"
 
 COPY tools/runtime_configs/python/$PYTHON_39_VERSION /root/.pyenv/plugins/python-build/share/python-build/$PYTHON_39_VERSION
 RUN   env PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install $PYTHON_39_VERSION && rm -rf /tmp/*

--- a/al2/x86_64/standard/4.0/runtimes.yml
+++ b/al2/x86_64/standard/4.0/runtimes.yml
@@ -34,6 +34,10 @@ runtimes:
         commands:
           - echo "Installing Python version 3.9 ..."
           - pyenv global  $PYTHON_39_VERSION
+      3.8:
+        commands:
+          - echo "Installing Python version 3.8 ..."
+          - pyenv global  $PYTHON_38_VERSION
   php:
     versions:
       8.1:

--- a/al2/x86_64/standard/4.0/tools/runtime_configs/python/3.8.13
+++ b/al2/x86_64/standard/4.0/tools/runtime_configs/python/3.8.13
@@ -1,0 +1,17 @@
+export PYTHON_CONFIGURE_OPTS="\
+            --enable-shared
+            --enable-loadable-sqlite-extensions"
+
+# Don't change below this line.
+# https://github.com/pyenv/pyenv/blob/master/plugins/python-build/share/python-build/3.8.13
+
+#require_gcc
+prefer_openssl11
+export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
+install_package "openssl-1.1.1n" "https://www.openssl.org/source/openssl-1.1.1n.tar.gz#40dceb51a4f6a5275bde0e6bf20ef4b91bfc32ed57c0552e2e8e15463372b17a" mac_openssl --if has_broken_mac_openssl
+install_package "readline-8.1" "https://ftpmirror.gnu.org/readline/readline-8.1.tar.gz#f8ceb4ee131e3232226a17f51b164afc46cd0b9e6cef344be87c65962cb82b02" mac_readline --if has_broken_mac_readline
+if has_tar_xz_support; then
+  install_package "Python-3.8.13" "https://www.python.org/ftp/python/3.8.13/Python-3.8.13.tar.xz#6f309077012040aa39fe8f0c61db8c0fa1c45136763299d375c9e5756f09cf57" standard verify_py38 copy_python_gdb ensurepip
+else
+  install_package "Python-3.8.13" "https://www.python.org/ftp/python/3.8.13/Python-3.8.13.tgz#903b92d76354366b1d9c4434d0c81643345cef87c1600adfa36095d7b00eede4" standard verify_py38 copy_python_gdb ensurepip
+fi


### PR DESCRIPTION
Add Python 3.8.13 support to CodeBuild 4.0 docker image.

Python 3.8 will be still be supported for 1 year and 5 months:
https://devguide.python.org/versions/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.