### PR TITLE
Fix buildspec override file location #585

### DIFF
--- a/local_builds/codebuild_build.sh
+++ b/local_builds/codebuild_build.sh
@@ -131,7 +131,7 @@ fi
 
 if [ -n "$buildspec" ]
 then
-    docker_command+=" -e \"BUILDSPEC=$(allOSRealPath "$buildspec")\""
+    docker_command+=" -e \"BUILDSPEC=$buildspec\""
 fi
 
 if [ -n "$environment_variable_file" ]


### PR DESCRIPTION
The buildspec override file location should be relative to CODEBUILD_SRC_DIR. Currently it's passing an absolute path based on the host.

*Issue #, if available:* #585

*Description of changes:*
Passed the buildspec override value as is.
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
