### PR TITLE
replace apt-key

### DIFF
--- a/ubuntu/standard/7.0/Dockerfile
+++ b/ubuntu/standard/7.0/Dockerfile
@@ -12,12 +12,15 @@ FROM public.ecr.aws/ubuntu/ubuntu:22.04 AS core
 
 ARG DEBIAN_FRONTEND="noninteractive"
 
+ADD https://download.mono-project.com/repo/xamarin.gpg /tmp/xamarin.gpg
+
 # Install git, SSH, and other utilities
 RUN set -ex \
     && echo 'Acquire::CompressionTypes::Order:: "gz";' > /etc/apt/apt.conf.d/99use-gzip-compression \
     && apt-get update \
     && apt install -y -qq apt-transport-https gnupg ca-certificates \
-    && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
+    && gpg --dearmor -o /etc/apt/keyrings/xamarin-mono-archive.gpg /tmp/xamarin.gpg \
+    && rm /tmp/xamarin.gpg \
     && apt-get install software-properties-common -y -qq --no-install-recommends \
     && apt-add-repository -y ppa:git-core/ppa \
     && apt-get update \


### PR DESCRIPTION
*Issue #, if available:*
Now apt-key is deprecated⁠ and should be replaced.

*Description of changes:*
Remove the apt-key and replace it by downloading the key from the Xamarin server and using it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
