### PR TITLE
fix symlink for golang runtime 1.20 in aarch64:standard:3.0

### DIFF
--- a/al2/aarch64/standard/3.0/runtimes.yml
+++ b/al2/aarch64/standard/3.0/runtimes.yml
@@ -28,7 +28,7 @@ runtimes:
         commands:
           - echo "Installing Go version 1.20 ..."
           - rm -rf /usr/local/go
-          - ln -s /usr/local/go12 /usr/local/go
+          - ln -s /usr/local/go20 /usr/local/go
   python:
     versions:
       3.11:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The symlink that is currently set when installing golang runtime 1.20 is currently pointing to a non-existing directory. The symlink should point to `/usr/local/go20` instead of `/usr/local/go12` as `go12` is the runtime for 1.12 (e.g as [used in aarch64:standard:2.0](https://github.com/aws/aws-codebuild-docker-images/blob/master/al2/aarch64/standard/2.0/runtimes.yml#L46-L50))

Currently this will lead to an error that the go binary could not be found when trying to run any `go` command.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
