### PR TITLE
Update nodejs version to 18.17.0

### DIFF
--- a/ubuntu/standard/7.0/Dockerfile
+++ b/ubuntu/standard/7.0/Dockerfile
@@ -179,7 +179,7 @@ RUN set -ex \
 
 #****************      NODEJS     ****************************************************
 
-ENV NODE_18_VERSION="18.16.1"
+ENV NODE_18_VERSION="18.17.0"
 
 RUN  n $NODE_18_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \
      && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \


### PR DESCRIPTION
I have some node packages that don't support on the current version of the codebuild standard:7 image which has the node version `18.16.1` so I needed to update the node version to 18.17.0

*Issue #668*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
