### PR TITLE
Addition of packCLI to AL2 CodeBuild images

### DIFF
--- a/al2/x86_64/standard/4.0/Dockerfile
+++ b/al2/x86_64/standard/4.0/Dockerfile
@@ -130,6 +130,12 @@ ENV GOPATH="/go"
 
 FROM tools AS runtimes_1
 
+#****************     Pack CLI     *************************************************
+RUN (curl -sSL "https://github.com/buildpacks/pack/releases/download/v0.32.1/pack-v0.32.1-linux.tgz" \
+    | tar -C /usr/local/bin/ --no-same-owner -xzv pack)
+
+#****************     END Pack CLI     *********************************************
+
 #****************      JAVA     ****************************************************
 
 ENV JAVA_17_HOME="/usr/lib/jvm/java-17-amazon-corretto.x86_64" \

--- a/al2/x86_64/standard/5.0/Dockerfile
+++ b/al2/x86_64/standard/5.0/Dockerfile
@@ -127,6 +127,12 @@ ENV GOPATH="/go"
 
 FROM tools AS runtimes_1
 
+#****************     Pack CLI     *************************************************
+RUN (curl -sSL "https://github.com/buildpacks/pack/releases/download/v0.32.1/pack-v0.32.1-linux.tgz" \
+    | tar -C /usr/local/bin/ --no-same-owner -xzv pack)
+
+#****************     END Pack CLI     *********************************************
+
 #****************      JAVA     ****************************************************
 
 ENV JAVA_17_HOME="/usr/lib/jvm/java-17-amazon-corretto.x86_64" \

--- a/unsupported_images/al2/x86_64/standard/3.0/Dockerfile
+++ b/unsupported_images/al2/x86_64/standard/3.0/Dockerfile
@@ -163,6 +163,12 @@ ENV GOPATH="/go"
 
 FROM tools AS runtimes_1
 
+#****************     Pack CLI     *************************************************
+RUN (curl -sSL "https://github.com/buildpacks/pack/releases/download/v0.32.1/pack-v0.32.1-linux.tgz" \
+    | tar -C /usr/local/bin/ --no-same-owner -xzv pack)
+
+#****************     END Pack CLI     *********************************************
+
 #****************      JAVA     ****************************************************
 COPY tools/android-accept-licenses.sh /opt/tools/android-accept-licenses.sh
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Includes PackCLI as part of AL2 CodeBuild image, so customers can use the pack commands to run container builds using buildpacks.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
