### PR TITLE
infra: add zstd to the standard-5.0 image

### DIFF
--- a/al2/x86_64/standard/5.0/Dockerfile
+++ b/al2/x86_64/standard/5.0/Dockerfile
@@ -36,7 +36,7 @@ RUN set -ex \
            perl-DBI perl-HTTP-Date perl-TimeDate perl-YAML-LibYAML \
            postgresql-devel procps-ng python-configobj readline-devel rsync sgml-common \
            subversion-perl tar tcl tk vim wget which xfsprogs xmlto xorg-x11-server-Xvfb xz-devel \
-           amazon-ecr-credential-helper git-lfs \
+           amazon-ecr-credential-helper git-lfs zstd \
     && rm /etc/yum.repos.d/mono-centos7-stable.repo
 
 RUN useradd codebuild-user


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This changes add in the [zstd](https://github.com/facebook/zstd) package, a common compression package, to the 5.0 image.

This can also be considered for other images.

Package info:
```
yum info zstd
Loaded plugins: priorities
934 packages excluded due to repository priority protections
Available Packages
Name        : zstd
Arch        : x86_64
Version     : 1.5.5
Release     : 1.amzn2.0.1
Size        : 455 k
Repo        : amzn2-core/x86_64
Summary     : Zstd compression library
URL         : https://github.com/facebook/zstd
License     : BSD and GPLv2
Description : Zstd, short for Zstandard, is a fast lossless compression algorithm,
            : targeting real-time compression scenarios at zlib-level compression ratio.
```

Testing done:
```
git clone git@github.com:math411/aws-codebuild-docker-images.git
cd aws-codebuild-docker-images
git checkout patch-1
cd ubuntu/standard/5.0
docker build -t aws/codebuild/standard:5.0 .
docker run -it --entrypoint sh aws/codebuild/standard:5.0 -c bash
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
