### PR TITLE
update runc and upgrade .Net versions on Ubuntu and AL(x86_64) images

### DIFF
--- a/al2/x86_64/standard/4.0/Dockerfile
+++ b/al2/x86_64/standard/4.0/Dockerfile
@@ -237,7 +237,7 @@ RUN set -ex \
     && ln -s /opt/microsoft/powershell/$POWERSHELL_VERSION/pwsh /usr/bin/pwsh
 
 #DotNet 6.0
-ENV DOTNET_60_SDK_VERSION="6.0.410"
+ENV DOTNET_60_SDK_VERSION="6.0.418"
 ENV DOTNET_ROOT="/root/.dotnet"
 
 # Add .NET Core 6.0 Global Tools install folder to PATH
@@ -338,6 +338,11 @@ RUN set -ex \
     && tar --extract --file docker.tgz --strip-components 1  --directory /usr/local/bin/ \
     && rm docker.tgz \
     && docker -v \
+    # replace runc package to resolve CVE-2024-21626
+    && yum -y install runc \
+    && rm -f /usr/local/bin/runc \
+    && ln -s /usr/sbin/runc /usr/local/bin/runc \
+    && runc -v \
     # set up subuid/subgid so that "--userns-remap=default" works out-of-the-box
     && groupadd dockremap \
     && useradd -g dockremap dockremap \

--- a/al2/x86_64/standard/5.0/Dockerfile
+++ b/al2/x86_64/standard/5.0/Dockerfile
@@ -244,8 +244,8 @@ RUN curl https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o /tmp/awscli
     && aws --version
 
 #DotNet 6.0
-ENV DOTNET_6_SDK_VERSION="6.0.417"
-ENV DOTNET_8_SDK_VERSION="8.0.100"
+ENV DOTNET_6_SDK_VERSION="6.0.418"
+ENV DOTNET_8_SDK_VERSION="8.0.101"
 ENV DOTNET_6_GLOBAL_JSON_SDK_VERSION="6.0.0"
 ENV DOTNET_8_GLOBAL_JSON_SDK_VERSION="8.0.0"
 ENV DOTNET_ROOT="/root/.dotnet"
@@ -377,6 +377,11 @@ RUN set -ex \
     && tar --extract --file docker.tgz --strip-components 1  --directory /usr/local/bin/ \
     && rm docker.tgz \
     && docker -v \
+    # replace runc package to resolve CVE-2024-21626
+    && yum -y install runc \
+    && rm -f /usr/local/bin/runc \
+    && ln -s /usr/sbin/runc /usr/local/bin/runc \
+    && runc -v \
     # set up subuid/subgid so that "--userns-remap=default" works out-of-the-box
     && groupadd dockremap \
     && useradd -g dockremap dockremap \

--- a/al2/x86_64/standard/corretto11/Dockerfile
+++ b/al2/x86_64/standard/corretto11/Dockerfile
@@ -86,6 +86,12 @@ RUN set -ex \
     && tar --extract --file docker.tgz --strip-components 1  --directory /usr/local/bin/ \
     && rm docker.tgz \
     && docker -v \
+    # replace runc package to resolve CVE-2024-21626
+    && amazon-linux-extras enable docker \
+    && yum -y install runc \
+    && rm -f /usr/local/bin/runc \
+    && ln -s /usr/sbin/runc /usr/local/bin/runc \
+    && runc -v \
     # set up subuid/subgid so that "--userns-remap=default" works out-of-the-box
     && groupadd dockremap \
     && useradd -g dockremap dockremap \

--- a/al2/x86_64/standard/corretto8/Dockerfile
+++ b/al2/x86_64/standard/corretto8/Dockerfile
@@ -86,6 +86,12 @@ RUN set -ex \
     && tar --extract --file docker.tgz --strip-components 1  --directory /usr/local/bin/ \
     && rm docker.tgz \
     && docker -v \
+    # replace runc package to resolve CVE-2024-21626
+    && amazon-linux-extras enable docker \
+    && yum -y install runc \
+    && rm -f /usr/local/bin/runc \
+    && ln -s /usr/sbin/runc /usr/local/bin/runc \
+    && runc -v \
     # set up subuid/subgid so that "--userns-remap=default" works out-of-the-box
     && groupadd dockremap \
     && useradd -g dockremap dockremap \

--- a/ubuntu/standard/5.0/Dockerfile
+++ b/ubuntu/standard/5.0/Dockerfile
@@ -434,6 +434,11 @@ RUN set -ex \
     && tar --extract --file docker.tgz --strip-components 1  --directory /usr/local/bin/ \
     && rm docker.tgz \
     && docker -v \
+    # replace runc package to resolve CVE-2024-21626
+    && apt-get update && apt-get -y install runc \
+    && rm -f /usr/local/bin/runc \
+    && ln -s /usr/sbin/runc /usr/local/bin/runc \
+    && runc -v \
     # set up subuid/subgid so that "--userns-remap=default" works out-of-the-box
     && addgroup dockremap \
     && useradd -g dockremap dockremap \

--- a/ubuntu/standard/6.0/Dockerfile
+++ b/ubuntu/standard/6.0/Dockerfile
@@ -143,7 +143,7 @@ FROM tools AS runtimes
 
 #****************     .NET-CORE     *******************************************************
 
-ENV DOTNET_6_SDK_VERSION="6.0.410"
+ENV DOTNET_6_SDK_VERSION="6.0.418"
 ENV DOTNET_ROOT="/root/.dotnet"
 
 # Add .NET Core 6 Global Tools install folder to PATH
@@ -353,6 +353,11 @@ RUN set -ex \
     && tar --extract --file docker.tgz --strip-components 1  --directory /usr/local/bin/ \
     && rm docker.tgz \
     && docker -v \
+    # replace runc package to resolve CVE-2024-21626
+    && apt-get update && apt-get -y install runc \
+    && rm -f /usr/local/bin/runc \
+    && ln -s /usr/sbin/runc /usr/local/bin/runc \
+    && runc -v \
     # set up subuid/subgid so that "--userns-remap=default" works out-of-the-box
     && addgroup dockremap \
     && useradd -g dockremap dockremap \

--- a/ubuntu/standard/7.0/Dockerfile
+++ b/ubuntu/standard/7.0/Dockerfile
@@ -159,8 +159,8 @@ FROM tools AS runtimes
 
 #****************     .NET-CORE     *******************************************************
 
-ENV DOTNET_6_SDK_VERSION="6.0.417"
-ENV DOTNET_8_SDK_VERSION="8.0.100"
+ENV DOTNET_6_SDK_VERSION="6.0.418"
+ENV DOTNET_8_SDK_VERSION="8.0.101"
 ENV DOTNET_6_GLOBAL_JSON_SDK_VERSION="6.0.0"
 ENV DOTNET_8_GLOBAL_JSON_SDK_VERSION="8.0.0"
 ENV DOTNET_ROOT="/root/.dotnet"
@@ -397,6 +397,11 @@ RUN set -ex \
     && tar --extract --file docker.tgz --strip-components 1  --directory /usr/local/bin/ \
     && rm docker.tgz \
     && docker -v \
+    # replace runc package to resolve CVE-2024-21626
+    && apt-get update && apt-get -y install runc \
+    && rm -f /usr/local/bin/runc \
+    && ln -s /usr/sbin/runc /usr/local/bin/runc \
+    && runc -v \
     # set up subuid/subgid so that "--userns-remap=default" works out-of-the-box
     && addgroup dockremap \
     && useradd -g dockremap dockremap \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Updated the runc package to resolve CVE-2024-21626
- Upgraded .Net versions to address CVE-2024-0056, CVE-2024-0057 and CVE-2024-21319
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
