### PR TITLE
Add Go 1.22 support

### DIFF
--- a/al2/aarch64/standard/3.0/runtimes.yml
+++ b/al2/aarch64/standard/3.0/runtimes.yml
@@ -57,6 +57,11 @@ runtimes:
         commands:
           - echo "Installing Go version 1.21 ..."
           - goenv global $GOLANG_21_VERSION
+      1.22:
+        commands:
+          - echo "Installing Latest Go version 1.22 ..."
+          - goenv install 1.22
+          - goenv global 1.22
   python:
     versions:
       3.11:

--- a/al2/x86_64/standard/5.0/runtimes.yml
+++ b/al2/x86_64/standard/5.0/runtimes.yml
@@ -43,6 +43,11 @@ runtimes:
             done
   golang:
     versions:
+      1.22:
+        commands:
+          - echo "Installing Latest Go version 1.22 ..."
+          - goenv install 1.22
+          - goenv global 1.22
       1.21:
         commands:
           - echo "Installing Go version 1.21 ..."

--- a/ubuntu/standard/7.0/runtimes.yml
+++ b/ubuntu/standard/7.0/runtimes.yml
@@ -51,6 +51,11 @@ runtimes:
         commands:
           - echo "Installing Go version 1.21 ..."
           - goenv global  $GOLANG_21_VERSION
+      1.22:
+        commands:
+          - echo "Installing Latest Go version 1.22 ..."
+          - goenv install 1.22
+          - goenv global 1.22
   python:
     versions:
       3.11:


### PR DESCRIPTION
*Issue #701*
*Description of changes:*
Add Go 1.22 Latest version

*Important Notes*
`goenv` now uses latest available patch version on `global` command. https://github.com/go-nv/goenv/issues/296