### PR TITLE
Add python uv support for Ubuntu Standard 7.0

### DIFF
--- a/ubuntu/standard/7.0/Dockerfile
+++ b/ubuntu/standard/7.0/Dockerfile
@@ -437,6 +437,11 @@ RUN set -ex \
     && pip3 install --no-build-isolation "Cython<3" "PyYAML==$PYYAML_VERSION" \
     && pip3 uninstall cython --yes \
     && rm -rf /tmp/*
+
+# Python uv
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH="/root/.local/bin:$PATH"
+
 #**************** END PYTHON *****************************************************
 
 #****************      PHP     ****************************************************

--- a/ubuntu/standard/7.0/runtimes.yml
+++ b/ubuntu/standard/7.0/runtimes.yml
@@ -130,6 +130,31 @@ runtimes:
         commands:
           - echo "Installing Python version 3.9 ..."
           - pyenv global $PYTHON_39_VERSION
+      3.13-uv:
+        commands:
+          - echo "Installing Python version $PYTHON_313_VERSION via uv ..."
+          - echo "Please use virtualenv via 'uv venv -p $PYTHON_313_VERSION'"
+          - uv python install $PYTHON_313_VERSION
+      3.12-uv:
+        commands:
+          - echo "Installing Python version $PYTHON_312_VERSION via uv ..."
+          - echo "Please use virtualenv via 'uv venv -p $PYTHON_312_VERSION'"
+          - uv python install $PYTHON_312_VERSION
+      3.11-uv:
+        commands:
+          - echo "Installing Python version $PYTHON_311_VERSION via uv ..."
+          - echo "Please use virtualenv via 'uv venv -p $PYTHON_311_VERSION'"
+          - uv python install $PYTHON_311_VERSION
+      3.10-uv:
+        commands:
+          - echo "Installing Python version $PYTHON_310_VERSION via uv ..."
+          - echo "Please use virtualenv via 'uv venv -p $PYTHON_310_VERSION'"
+          - uv python install $PYTHON_310_VERSION
+      3.9-uv:
+        commands:
+          - echo "Installing Python version $PYTHON_39_VERSION via uv ..."
+          - echo "Please use virtualenv via 'uv venv -p $PYTHON_39_VERSION'"
+          - uv python install $PYTHON_39_VERSION
       default:
         commands:
           - echo "Installing custom Python version $VERSION ..."


### PR DESCRIPTION
*Issue [#779](https://github.com/aws/aws-codebuild-docker-images/issues/779):*

*Description of changes:*

This change added a famous python tool called python uv for Ubuntu standard 7.0 image.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
