### PR TITLE
Add PHP 8.4 support

### DIFF
--- a/al/x86_64/standard/5.0/Dockerfile
+++ b/al/x86_64/standard/5.0/Dockerfile
@@ -468,7 +468,8 @@ RUN set -ex \
 RUN curl -L https://raw.githubusercontent.com/phpenv/phpenv-installer/master/bin/phpenv-installer | bash
 ENV PATH="/root/.phpenv/shims:/root/.phpenv/bin:$PATH"
 
-ENV PHP_83_VERSION="8.3.13" \
+ENV PHP_84_VERSION="8.4.7" \
+    PHP_83_VERSION="8.3.13" \
     PHP_82_VERSION="8.2.25"
 # Set environment variables for PHP configure options
 ENV PHP_BUILD_CONFIGURE_OPTS="--with-curl --with-password-argon2 --with-pdo-pgsql --with-libedit"
@@ -476,10 +477,12 @@ ENV PHP_BUILD_CONFIGURE_OPTS="--with-curl --with-password-argon2 --with-pdo-pgsq
 ENV PHP_BUILD_EXTRA_MAKE_ARGUMENTS="-j4"
 
 RUN phpenv update \
+    && phpenv install $PHP_84_VERSION \
     && phpenv install $PHP_83_VERSION \
     && phpenv install $PHP_82_VERSION \
     && phpenv global $PHP_82_VERSION \
     && php -v \
+    && echo "memory_limit = 1G;" >> "/root/.phpenv/versions/$PHP_84_VERSION/etc/conf.d/memory.ini" \
     && echo "memory_limit = 1G;" >> "/root/.phpenv/versions/$PHP_83_VERSION/etc/conf.d/memory.ini" \
     && echo "memory_limit = 1G;" >> "/root/.phpenv/versions/$PHP_82_VERSION/etc/conf.d/memory.ini" \
     && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer \

--- a/al/x86_64/standard/5.0/runtimes.yml
+++ b/al/x86_64/standard/5.0/runtimes.yml
@@ -131,6 +131,10 @@ runtimes:
           - pyenv global $VERSION
   php:
     versions:
+      8.4:
+        commands:
+          - echo "Installing PHP version 8.4 ..."
+          - phpenv global $PHP_84_VERSION
       8.3:
         commands:
           - echo "Installing PHP version 8.3 ..."

--- a/al/x86_64/standard/5.0/tools/runtime_configs/php/8.4.7
+++ b/al/x86_64/standard/5.0/tools/runtime_configs/php/8.4.7
@@ -1,0 +1,20 @@
+configure_option "--with-curl"
+configure_option "--with-password-argon2"
+configure_option "--with-pdo-pgsql"
+configure_option "--with-libedit"
+
+PHP_BUILD_EXTRA_MAKE_ARGUMENTS="-j4"
+
+#https://github.com/php-build/php-build/blob/master/share/php-build/definitions/8.4.7
+#Don't change beyond this line
+
+configure_option "--enable-gd"
+configure_option "--with-jpeg"
+configure_option "--with-zip"
+configure_option "--with-mhash"
+
+configure_option -D "--with-xmlrpc"
+
+install_package "https://www.php.net/distributions/php-8.4.7.tar.bz2"
+install_xdebug "3.4.2"
+enable_builtin_opcache

--- a/ubuntu/standard/7.0/Dockerfile
+++ b/ubuntu/standard/7.0/Dockerfile
@@ -445,7 +445,8 @@ RUN set -ex \
 RUN curl -L https://raw.githubusercontent.com/phpenv/phpenv-installer/master/bin/phpenv-installer | bash
 ENV PATH="/root/.phpenv/shims:/root/.phpenv/bin:$PATH"
 
-ENV PHP_83_VERSION="8.3.13" \
+ENV PHP_84_VERSION="8.4.7" \
+    PHP_83_VERSION="8.3.13" \
     PHP_82_VERSION="8.2.25"
 # Set environment variables for PHP configure options
 ENV PHP_BUILD_CONFIGURE_OPTS="--with-curl --with-password-argon2 --with-pdo-pgsql --with-libedit"
@@ -453,10 +454,12 @@ ENV PHP_BUILD_CONFIGURE_OPTS="--with-curl --with-password-argon2 --with-pdo-pgsq
 ENV PHP_BUILD_EXTRA_MAKE_ARGUMENTS="-j4"
 
 RUN phpenv update \
+    && phpenv install $PHP_84_VERSION \
     && phpenv install $PHP_83_VERSION \
     && phpenv install $PHP_82_VERSION \
     && phpenv global $PHP_82_VERSION \
     && php -v \
+    && echo "memory_limit = 1G;" >> "/root/.phpenv/versions/$PHP_84_VERSION/etc/conf.d/memory.ini" \
     && echo "memory_limit = 1G;" >> "/root/.phpenv/versions/$PHP_83_VERSION/etc/conf.d/memory.ini" \
     && echo "memory_limit = 1G;" >> "/root/.phpenv/versions/$PHP_82_VERSION/etc/conf.d/memory.ini" \
     && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer \

--- a/ubuntu/standard/7.0/runtimes.yml
+++ b/ubuntu/standard/7.0/runtimes.yml
@@ -137,6 +137,10 @@ runtimes:
           - pyenv global $VERSION
   php:
     versions:
+      8.4:
+        commands:
+          - echo "Installing PHP version 8.4 ..."
+          - phpenv global $PHP_84_VERSION
       8.3:
         commands:
           - echo "Installing PHP version 8.3 ..."

--- a/ubuntu/standard/7.0/tools/runtime_configs/php/8.4.7
+++ b/ubuntu/standard/7.0/tools/runtime_configs/php/8.4.7
@@ -1,0 +1,20 @@
+configure_option "--with-curl"
+configure_option "--with-password-argon2"
+configure_option "--with-pdo-pgsql"
+configure_option "--with-libedit"
+
+PHP_BUILD_EXTRA_MAKE_ARGUMENTS="-j4"
+
+#https://github.com/php-build/php-build/blob/master/share/php-build/definitions/8.4.7
+#Don't change beyond this line
+
+configure_option "--enable-gd"
+configure_option "--with-jpeg"
+configure_option "--with-zip"
+configure_option "--with-mhash"
+
+configure_option -D "--with-xmlrpc"
+
+install_package "https://www.php.net/distributions/php-8.4.7.tar.bz2"
+install_xdebug "3.4.2"
+enable_builtin_opcache


### PR DESCRIPTION
*Issue #, if available:*
#750 

*Description of changes:*
Added PHP 8.4 support to Ubuntu Standard 7.0 and AL x86_64 standard 5.0.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
