### PR TITLE
Add installation commands for Node.js version 24 (Ubuntu Standard 7.0)

### DIFF
--- a/ubuntu/standard/7.0/runtimes.yml
+++ b/ubuntu/standard/7.0/runtimes.yml
@@ -179,6 +179,10 @@ runtimes:
           - rbenv global $VERSION
   nodejs:
     versions:
+      24:
+        commands:
+          - echo "Installing Node.js version 24 ..."
+          - n $NODE_24_VERSION
       22:
         commands:
           - echo "Installing Node.js version 22 ..."


### PR DESCRIPTION
*Issue #803*

*Description of changes:*
Add Node.js 24 also to the runtimes.yml
https://github.com/aws/aws-codebuild-docker-images/blob/master/ubuntu/standard/7.0/runtimes.yml#L181

Was already added to the Dockerfile.
https://github.com/aws/aws-codebuild-docker-images/blob/master/ubuntu/standard/7.0/Dockerfile#L328
PR: https://github.com/aws/aws-codebuild-docker-images/pull/792/files#diff-397d7e615a01917f9785bf3388d73f475f14d45c3f37cc46e273ca695c855861R345

24 is already LTS: https://github.com/nodejs/Release
And is also available for e.g. Lambda: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtimes-supported

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
