### PR TITLE
Add Node 24 to aarch64, x86_64 and ubuntu images and runtimes

### DIFF
--- a/al/aarch64/standard/3.0/Dockerfile
+++ b/al/aarch64/standard/3.0/Dockerfile
@@ -290,7 +290,8 @@ RUN set -ex \
 
 #****************      NODEJS     ****************************************************
 
-ENV NODE_22_VERSION="22.20.0" \
+ENV NODE_24_VERSION="24.13.0" \
+    NODE_22_VERSION="22.20.0" \
     NODE_20_VERSION="20.19.5" \
     NODE_18_VERSION="18.20.8"
 
@@ -304,6 +305,10 @@ RUN n --no-preserve $NODE_18_VERSION && npm install --save-dev -g -f grunt \
     && npm install --save-dev -g -f yarn \
     && dnf install -y -v libuv-1.44* \
     && n $NODE_22_VERSION && npm install --save-dev -g -f grunt \
+    && npm install --save-dev -g -f grunt-cli \
+    && npm install --save-dev -g -f webpack \
+    && npm install --save-dev -g -f yarn \
+    && n $NODE_24_VERSION && npm install --save-dev -g -f grunt \
     && npm install --save-dev -g -f grunt-cli \
     && npm install --save-dev -g -f webpack \
     && npm install --save-dev -g -f yarn \

--- a/al/aarch64/standard/3.0/runtimes.yml
+++ b/al/aarch64/standard/3.0/runtimes.yml
@@ -176,6 +176,10 @@ runtimes:
           - rbenv global $VERSION
   nodejs:
     versions:
+      24:
+        commands:
+          - echo "Installing Node.js version 24 ..."
+          - n $NODE_24_VERSION
       22:
         commands:
           - echo "Installing Node.js version 22 ..."

--- a/al/x86_64/standard/5.0/runtimes.yml
+++ b/al/x86_64/standard/5.0/runtimes.yml
@@ -173,6 +173,10 @@ runtimes:
           - rbenv global $VERSION
   nodejs:
     versions:
+      24:
+        commands:
+          - echo "Installing Node.js version 24 ..."
+          - n $NODE_24_VERSION
       22:
         commands:
           - echo "Installing Node.js version 22 ..."

--- a/ubuntu/standard/7.0/runtimes.yml
+++ b/ubuntu/standard/7.0/runtimes.yml
@@ -179,6 +179,10 @@ runtimes:
           - rbenv global $VERSION
   nodejs:
     versions:
+      24:
+        commands:
+          - echo "Installing Node.js version 24 ..."
+          - n $NODE_24_VERSION
       22:
         commands:
           - echo "Installing Node.js version 22 ..."


### PR DESCRIPTION
*Issue #803*

*Description of changes:*
Add Node.js 24 also to the runtimes.yml
https://github.com/aws/aws-codebuild-docker-images/blob/master/ubuntu/standard/7.0/runtimes.yml#L181

Was already added to the Dockerfile.
https://github.com/aws/aws-codebuild-docker-images/blob/master/ubuntu/standard/7.0/Dockerfile#L328
PR: https://github.com/aws/aws-codebuild-docker-images/pull/792/files#diff-397d7e615a01917f9785bf3388d73f475f14d45c3f37cc46e273ca695c855861R345

24 is already LTS: https://github.com/nodejs/Release
And is also available for e.g. Lambda: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtimes-supported

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
