### PR TITLE
Update goenv clone URLs

### DIFF
--- a/al/aarch64/standard/2.0/Dockerfile
+++ b/al/aarch64/standard/2.0/Dockerfile
@@ -119,7 +119,7 @@ RUN curl -L https://raw.githubusercontent.com/phpenv/phpenv-installer/master/bin
 ENV PATH="/root/.phpenv/shims:/root/.phpenv/bin:$PATH"
 
 ##go
-RUN git clone https://github.com/syndbg/goenv.git $HOME/.goenv
+RUN git clone -b master https://github.com/go-nv/goenv.git $HOME/.goenv
 ENV PATH="/root/.goenv/shims:/root/.goenv/bin:/go/bin:$PATH"
 ENV GOENV_DISABLE_GOPATH=1
 ENV GOPATH="/go"

--- a/al/aarch64/standard/3.0/Dockerfile
+++ b/al/aarch64/standard/3.0/Dockerfile
@@ -157,7 +157,7 @@ RUN curl -L https://raw.githubusercontent.com/phpenv/phpenv-installer/master/bin
 ENV PATH="/root/.phpenv/shims:/root/.phpenv/bin:$PATH"
 
 ##go
-RUN git clone https://github.com/syndbg/goenv.git $HOME/.goenv
+RUN git clone -b master https://github.com/go-nv/goenv.git $HOME/.goenv
 ENV PATH="/root/.goenv/shims:/root/.goenv/bin:/go/bin:$PATH"
 ENV GOENV_DISABLE_GOPATH=1
 ENV GOPATH="/go"

--- a/al/aarch64/standard/4.0/Dockerfile
+++ b/al/aarch64/standard/4.0/Dockerfile
@@ -156,7 +156,7 @@ RUN curl -L https://raw.githubusercontent.com/phpenv/phpenv-installer/master/bin
 ENV PATH="/root/.phpenv/shims:/root/.phpenv/bin:$PATH"
 
 ##go
-RUN git clone https://github.com/syndbg/goenv.git $HOME/.goenv
+RUN git clone -b master https://github.com/go-nv/goenv.git $HOME/.goenv
 ENV PATH="/root/.goenv/shims:/root/.goenv/bin:/go/bin:$PATH"
 ENV GOENV_DISABLE_GOPATH=1
 ENV GOPATH="/go"

--- a/al/x86_64/standard/4.0/Dockerfile
+++ b/al/x86_64/standard/4.0/Dockerfile
@@ -122,7 +122,7 @@ RUN curl -L https://raw.githubusercontent.com/phpenv/phpenv-installer/master/bin
 ENV PATH="/root/.phpenv/shims:/root/.phpenv/bin:$PATH"
 
 ##go
-RUN git clone https://github.com/syndbg/goenv.git $HOME/.goenv
+RUN git clone -b master https://github.com/go-nv/goenv.git $HOME/.goenv
 ENV PATH="/root/.goenv/shims:/root/.goenv/bin:/go/bin:$PATH"
 ENV GOENV_DISABLE_GOPATH=1
 ENV GOPATH="/go"

--- a/al/x86_64/standard/5.0/Dockerfile
+++ b/al/x86_64/standard/5.0/Dockerfile
@@ -465,7 +465,7 @@ RUN phpenv update \
 #****************     GOLANG     ****************************************************
 
 #goenv
-RUN git clone https://github.com/syndbg/goenv.git $HOME/.goenv
+RUN git clone -b master https://github.com/go-nv/goenv.git $HOME/.goenv
 ENV PATH="/root/.goenv/shims:/root/.goenv/bin:/go/bin:$PATH"
 
 ENV GOLANG_26_VERSION="1.26.0" \

--- a/al/x86_64/standard/6.0/Dockerfile
+++ b/al/x86_64/standard/6.0/Dockerfile
@@ -468,7 +468,7 @@ RUN phpenv update \
 #****************     GOLANG     ****************************************************
 
 #goenv
-RUN git clone https://github.com/syndbg/goenv.git $HOME/.goenv
+RUN git clone -b master https://github.com/go-nv/goenv.git $HOME/.goenv
 ENV PATH="/root/.goenv/shims:/root/.goenv/bin:/go/bin:$PATH"
 
 ENV GOLANG_26_VERSION="1.26.0" \

--- a/ubuntu/standard/5.0/Dockerfile
+++ b/ubuntu/standard/5.0/Dockerfile
@@ -171,7 +171,7 @@ RUN curl -L https://raw.githubusercontent.com/phpenv/phpenv-installer/master/bin
 ENV PATH="/root/.phpenv/shims:/root/.phpenv/bin:$PATH"
 
 #go
-RUN git clone https://github.com/syndbg/goenv.git $HOME/.goenv
+RUN git clone -b master https://github.com/go-nv/goenv.git $HOME/.goenv
 ENV PATH="/root/.goenv/shims:/root/.goenv/bin:/go/bin:$PATH"
 ENV GOENV_DISABLE_GOPATH=1
 ENV GOPATH="/go"

--- a/ubuntu/standard/6.0/Dockerfile
+++ b/ubuntu/standard/6.0/Dockerfile
@@ -142,7 +142,7 @@ RUN curl -L https://raw.githubusercontent.com/phpenv/phpenv-installer/master/bin
 ENV PATH="/root/.phpenv/shims:/root/.phpenv/bin:$PATH"
 
 #go
-RUN git clone https://github.com/syndbg/goenv.git $HOME/.goenv
+RUN git clone -b master https://github.com/go-nv/goenv.git $HOME/.goenv
 ENV PATH="/root/.goenv/shims:/root/.goenv/bin:/go/bin:$PATH"
 ENV GOENV_DISABLE_GOPATH=1
 ENV GOPATH="/go"

--- a/ubuntu/standard/7.0/Dockerfile
+++ b/ubuntu/standard/7.0/Dockerfile
@@ -446,7 +446,7 @@ RUN phpenv update \
 #****************     GOLANG     ****************************************************
 
 #goenv
-RUN git clone https://github.com/syndbg/goenv.git $HOME/.goenv
+RUN git clone -b master https://github.com/go-nv/goenv.git $HOME/.goenv
 ENV PATH="/root/.goenv/shims:/root/.goenv/bin:/go/bin:$PATH"
 
 ENV GOLANG_26_VERSION="1.26.0" \

--- a/ubuntu/standard/8.0/Dockerfile
+++ b/ubuntu/standard/8.0/Dockerfile
@@ -444,7 +444,7 @@ RUN phpenv update \
 #****************     GOLANG     ****************************************************
 
 #goenv
-RUN git clone https://github.com/syndbg/goenv.git $HOME/.goenv
+RUN git clone -b master https://github.com/go-nv/goenv.git $HOME/.goenv
 ENV PATH="/root/.goenv/shims:/root/.goenv/bin:/go/bin:$PATH"
 
 ENV GOLANG_26_VERSION="1.26.0" \

--- a/unsupported_images/al2/x86_64/standard/1.0/Dockerfile
+++ b/unsupported_images/al2/x86_64/standard/1.0/Dockerfile
@@ -153,7 +153,7 @@ RUN curl -L https://raw.githubusercontent.com/phpenv/phpenv-installer/master/bin
 ENV PATH="/root/.phpenv/shims:/root/.phpenv/bin:$PATH"
 
 ##go
-RUN git clone https://github.com/syndbg/goenv.git $HOME/.goenv
+RUN git clone -b master https://github.com/go-nv/goenv.git $HOME/.goenv
 ENV PATH="/root/.goenv/shims:/root/.goenv/bin:/go/bin:$PATH"
 ENV GOENV_DISABLE_GOPATH=1
 ENV GOPATH="/go"

--- a/unsupported_images/al2/x86_64/standard/2.0/Dockerfile
+++ b/unsupported_images/al2/x86_64/standard/2.0/Dockerfile
@@ -151,7 +151,7 @@ RUN curl -L https://raw.githubusercontent.com/phpenv/phpenv-installer/master/bin
 ENV PATH="/root/.phpenv/shims:/root/.phpenv/bin:$PATH"
 
 ##go
-RUN git clone https://github.com/syndbg/goenv.git $HOME/.goenv
+RUN git clone -b master https://github.com/go-nv/goenv.git $HOME/.goenv
 ENV PATH="/root/.goenv/shims:/root/.goenv/bin:/go/bin:$PATH"
 ENV GOENV_DISABLE_GOPATH=1
 ENV GOPATH="/go"

--- a/unsupported_images/al2/x86_64/standard/3.0/Dockerfile
+++ b/unsupported_images/al2/x86_64/standard/3.0/Dockerfile
@@ -154,7 +154,7 @@ RUN curl -L https://raw.githubusercontent.com/phpenv/phpenv-installer/master/bin
 ENV PATH="/root/.phpenv/shims:/root/.phpenv/bin:$PATH"
 
 ##go
-RUN git clone https://github.com/syndbg/goenv.git $HOME/.goenv
+RUN git clone -b master https://github.com/go-nv/goenv.git $HOME/.goenv
 ENV PATH="/root/.goenv/shims:/root/.goenv/bin:/go/bin:$PATH"
 ENV GOENV_DISABLE_GOPATH=1
 ENV GOPATH="/go"

--- a/unsupported_images/ubuntu/standard/1.0/Dockerfile
+++ b/unsupported_images/ubuntu/standard/1.0/Dockerfile
@@ -164,7 +164,7 @@ RUN curl -L https://raw.githubusercontent.com/phpenv/phpenv-installer/master/bin
 ENV PATH="/root/.phpenv/shims:/root/.phpenv/bin:$PATH"
 
 #go
-RUN git clone https://github.com/syndbg/goenv.git $HOME/.goenv
+RUN git clone -b master https://github.com/go-nv/goenv.git $HOME/.goenv
 ENV PATH="/root/.goenv/shims:/root/.goenv/bin:/go/bin:$PATH"
 ENV GOENV_DISABLE_GOPATH=1
 ENV GOPATH="/go"

--- a/unsupported_images/ubuntu/standard/2.0/Dockerfile
+++ b/unsupported_images/ubuntu/standard/2.0/Dockerfile
@@ -164,7 +164,7 @@ RUN curl -L https://raw.githubusercontent.com/phpenv/phpenv-installer/master/bin
 ENV PATH="/root/.phpenv/shims:/root/.phpenv/bin:$PATH"
 
 #go
-RUN git clone https://github.com/syndbg/goenv.git $HOME/.goenv
+RUN git clone -b master https://github.com/go-nv/goenv.git $HOME/.goenv
 ENV PATH="/root/.goenv/shims:/root/.goenv/bin:/go/bin:$PATH"
 ENV GOENV_DISABLE_GOPATH=1
 ENV GOPATH="/go"

--- a/unsupported_images/ubuntu/standard/3.0/Dockerfile
+++ b/unsupported_images/ubuntu/standard/3.0/Dockerfile
@@ -164,7 +164,7 @@ RUN curl -L https://raw.githubusercontent.com/phpenv/phpenv-installer/master/bin
 ENV PATH="/root/.phpenv/shims:/root/.phpenv/bin:$PATH"
 
 #go
-RUN git clone https://github.com/syndbg/goenv.git $HOME/.goenv
+RUN git clone -b master https://github.com/go-nv/goenv.git $HOME/.goenv
 ENV PATH="/root/.goenv/shims:/root/.goenv/bin:/go/bin:$PATH"
 ENV GOENV_DISABLE_GOPATH=1
 ENV GOPATH="/go"

--- a/unsupported_images/ubuntu/standard/4.0/Dockerfile
+++ b/unsupported_images/ubuntu/standard/4.0/Dockerfile
@@ -164,7 +164,7 @@ RUN curl -L https://raw.githubusercontent.com/phpenv/phpenv-installer/master/bin
 ENV PATH="/root/.phpenv/shims:/root/.phpenv/bin:$PATH"
 
 #go
-RUN git clone https://github.com/syndbg/goenv.git $HOME/.goenv
+RUN git clone -b master https://github.com/go-nv/goenv.git $HOME/.goenv
 ENV PATH="/root/.goenv/shims:/root/.goenv/bin:/go/bin:$PATH"
 ENV GOENV_DISABLE_GOPATH=1
 ENV GOPATH="/go"


### PR DESCRIPTION
I am one of the owners of https://github.com/go-nv/goenv (formerly syndbg/goenv). We are releasing V3 and providing support for V2 until EoY 2028. Until then I need to update the docker clone to specifically target `master` as it is the v2 branch.

Action plan is to figure out a testing strategy when we move to the docker scripts to use the compiled binaries. This change will come later and am open to suggestions.

*Issue #, if available:* #816

*Description of changes:*

`master` branch will no longer be the default and move to `main`.

`master` is the legacy v2 model and `main` is v3 - a fully go-based CLI. We will need some time to migrate these images to use the compiled binaries instead and add support for all platforms/archs.

We plan to keep support until EoY 2028. This will give us plenty of time to test and migrate everything safely and correctly

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
